### PR TITLE
Fixed unsigned int / int comparision

### DIFF
--- a/src/vcml/models/generic/pci_device.cpp
+++ b/src/vcml/models/generic/pci_device.cpp
@@ -384,7 +384,7 @@ namespace vcml { namespace generic {
     }
 
     void pci_device::update_bars() {
-        for (int barno = 0; barno < PCI_NUM_BARS; barno++) {
+        for (unsigned int barno = 0; barno < PCI_NUM_BARS; barno++) {
             pci_bar* bar = m_bars + barno;
             if (bar->size == 0)
                 continue;


### PR DESCRIPTION
GCC 10.3.0 doesn't compile the recent version of vcml if warnings are treated as errors due to a comparison between `int` and `unsigned int` variables.
I also enabled `Werrror` in vcml.