### PR TITLE
Ignore EINTR in aio thread

### DIFF
--- a/src/vcml/core/aio.cpp
+++ b/src/vcml/core/aio.cpp
@@ -57,7 +57,17 @@ private:
             }
 
             int ret = poll(polls.data(), polls.size(), TIMEOUT_MS);
-            VCML_ERROR_ON(ret < 0, "aio error: %s", strerror(errno));
+
+            if (ret < 0) {
+                int errnum = errno;
+
+                if (errnum == EINTR) {
+                    // ingnore interrupted system calls
+                    continue;
+                }
+                VCML_ERROR("aio error: %s", strerror(errnum));
+            }
+
             vector<pair<int, aio_handler>> scheduled;
 
             if (ret > 0 && m_running) {


### PR DESCRIPTION
When `poll` returns with `EINTR`, it means that the call was interrupted by a signal handler. In this case, poll is restarted instead of exiting the simulation with an error.