### PR TITLE
Add ncurses TUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,8 +257,13 @@ if(NCURSES_FOUND)
     message(STATUS "Building with ncurses support")
     target_compile_definitions(vcml PRIVATE HAVE_NCURSES)
     target_include_directories(vcml SYSTEM PRIVATE ${NCURSES_INCLUDE_DIR})
-    target_sources(vcml PRIVATE ${src}/vcml/models/serial/backend_tui.cpp)
+    target_sources(vcml PRIVATE ${src}/vcml/logging/log_tui.cpp 
+                        PRIVATE ${src}/vcml/models/serial/backend_tui.cpp
+                        PRIVATE ${src}/vcml/core/ncurses.cpp
+                        PRIVATE ${src}/vcml/ui/tui.cpp)
     target_link_libraries(vcml PUBLIC ${NCURSES_LIBRARIES})
+    # Shush SystemC
+    set(DISABLE_COPYRIGHT_MESSAGE true)
 else()
     message(STATUS "Building without ncurses support")
 endif()

--- a/include/vcml.h
+++ b/include/vcml.h
@@ -24,8 +24,10 @@
 #include "vcml/core/processor.h"
 #include "vcml/core/system.h"
 #include "vcml/core/setup.h"
+#include "vcml/core/ncurses.h"
 
 #include "vcml/logging/logger.h"
+#include "vcml/logging/log_tui.h"
 
 #include "vcml/tracing/tracer.h"
 #include "vcml/tracing/tracer_file.h"
@@ -53,6 +55,7 @@
 #include "vcml/ui/video.h"
 #include "vcml/ui/display.h"
 #include "vcml/ui/console.h"
+#include "vcml/ui/tui.h"
 
 #include "vcml/protocols/tlm.h"
 #include "vcml/protocols/gpio.h"

--- a/include/vcml/core/ncurses.h
+++ b/include/vcml/core/ncurses.h
@@ -1,0 +1,87 @@
+#ifndef VCML_CORE_NCURSES_H
+#define VCML_CORE_NCURSES_H
+
+#include "vcml/core/types.h"
+
+#include <ncurses.h>
+
+#define COLPAIR(FG, BG) (FG << 4 | BG)
+#define FGCOL(FG)       COLPAIR(FG, ncurses::colors::BLACK)
+
+namespace vcml {
+namespace ncurses {
+
+struct dimensions {
+    int colums;
+    int lines;
+};
+
+struct position {
+    int x;
+    int y;
+};
+
+enum colors { BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE };
+
+enum ansi_escape_mode { NONE, CSI };
+
+class window
+{
+private:
+    std::unique_ptr<::WINDOW> m_win;
+
+    bool m_escape_enabled;
+    ansi_escape_mode m_curr_mode;
+    queue<u8> m_escape_args;
+
+    mutex m_mtx;
+
+public:
+    window() = delete;
+    window(WINDOW* win);
+    window(const dimensions& dim, const position& pos);
+    ~window();
+
+    void draw_border(const char ls, const char rs, const char ts,
+                     const char bs, const char tl, const char tr,
+                     const char bl, const char br);
+
+    void write(const char val);
+    void write(const std::string& str);
+    void write(const std::string& str, const position& pos);
+    void write(const std::string& str, const int color);
+
+    void set_scrolling(const bool enable);
+    void set_timeout(const int timeout_ms = 100);
+
+    position get_curs_pos() const;
+    void move_curs(const position& pos);
+
+    void refresh();
+
+    i8 get_char() const;
+
+    void clear_to_bottom();
+    void clear_screen();
+
+    void newline();
+};
+
+class terminal
+{
+private:
+    ncurses::window m_main_win;
+
+public:
+    terminal();
+    ~terminal();
+
+    dimensions get_dimensions();
+    ncurses::window& get_win() { return m_main_win; }
+
+    void refresh();
+};
+} // namespace ncurses
+} // namespace vcml
+
+#endif

--- a/include/vcml/core/setup.h
+++ b/include/vcml/core/setup.h
@@ -13,6 +13,9 @@
 
 #include "vcml/core/types.h"
 #include "vcml/core/thctl.h"
+#include "vcml/core/ncurses.h"
+
+#include "vcml/logging/log_tui.h"
 
 #include "vcml/tracing/tracer.h"
 #include "vcml/tracing/tracer_file.h"

--- a/include/vcml/logging/log_tui.h
+++ b/include/vcml/logging/log_tui.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *                                                                            *
- * Copyright (C) 2023 MachineWare GmbH                                        *
+ * Copyright (C) 2022 MachineWare GmbH                                        *
  * All Rights Reserved                                                        *
  *                                                                            *
  * This is work is licensed under the terms described in the LICENSE file     *
@@ -8,46 +8,34 @@
  *                                                                            *
  ******************************************************************************/
 
-#ifndef VCML_SERIAL_BACKEND_TUI_H
-#define VCML_SERIAL_BACKEND_TUI_H
+#ifndef VCML_LOG_TUI_H
+#define VCML_LOG_TUI_H
 
 #include "vcml/core/types.h"
-#include "vcml/logging/logger.h"
-#include "vcml/models/serial/backend.h"
+#include "mwr/logging/publisher.h"
 
 #include "vcml/ui/tui.h"
 
 namespace vcml {
-namespace serial {
 
-class backend_tui : public backend
+class log_tui : public mwr::publisher
 {
 private:
-    atomic<bool> m_exit_requested;
-    atomic<bool> m_backend_active;
-
-    thread m_iothread;
-    mutable mutex m_mtx;
-    queue<u8> m_fifo;
-
-    ncurses::window& m_win;
-
-    void iothread();
-    void terminate();
+    bool m_colors;
 
 public:
-    logger log;
+    bool has_colors() const { return m_colors; }
+    void set_colors(bool set = true) { m_colors = set; }
 
-    backend_tui(terminal* term);
-    virtual ~backend_tui();
+    log_tui() = delete;
+    log_tui(bool use_colors);
+    virtual ~log_tui() = default;
 
-    virtual bool read(u8& val) override;
-    virtual void write(u8 val) override;
+    virtual void publish(const mwr::logmsg& msg) override;
 
-    static backend* create(terminal* term, const string& type);
+    static const int COLORS[mwr::log_level::NUM_LOG_LEVELS];
 };
 
-} // namespace serial
 } // namespace vcml
 
 #endif

--- a/include/vcml/ui/tui.h
+++ b/include/vcml/ui/tui.h
@@ -1,0 +1,38 @@
+#ifndef VCML_UI_TUI_H
+#define VCML_UI_TUI_H
+
+#include "vcml/core/types.h"
+#include "vcml/core/systemc.h"
+#include "vcml/core/ncurses.h"
+
+namespace vcml {
+namespace ui {
+class tui
+{
+private:
+    ncurses::terminal m_term;
+    ncurses::window m_tui_window;
+
+    thread m_tui_thread;
+
+    static tui* tui_instance;
+
+    void tuithread();
+
+    tui();
+    ~tui() = delete;
+
+public:
+    tui(const tui&) = delete;
+    tui(tui&&) = delete;
+    tui& operator=(const tui&) = delete;
+    tui& operator=(tui&&) = delete;
+
+    static tui* instance();
+
+    ncurses::window& get_tui_window();
+};
+} // namespace ui
+} // namespace vcml
+
+#endif

--- a/src/vcml/core/ncurses.cpp
+++ b/src/vcml/core/ncurses.cpp
@@ -1,0 +1,226 @@
+#include "vcml/core/ncurses.h"
+
+#define ASCII_TO_INT(x) ((int)(x - 0x30))
+
+namespace vcml {
+namespace ncurses {
+
+int get_escape_arg(queue<u8>& queue) {
+    int tmp = 0;
+    while (queue.front() != ';' && !queue.empty()) {
+        tmp = tmp * 10 + ASCII_TO_INT(queue.front());
+        queue.pop();
+    }
+    if (!queue.empty())
+        queue.pop();
+    return tmp;
+}
+
+window::window(::WINDOW* win): m_win(std::unique_ptr<::WINDOW>(win)), m_mtx() {
+    if (!m_win) {
+        printf("Could not initialize TUI!");
+        std::abort();
+    }
+}
+
+window::window(const dimensions& dim, const position& pos):
+    m_win(::newwin(dim.lines, dim.colums, pos.y, pos.x)), m_mtx() {
+    set_scrolling(true);
+    set_timeout();
+}
+
+window::~window() {
+    ::delwin(m_win.get());
+    m_win.release();
+}
+
+void window::draw_border(const char ls, const char rs, const char ts,
+                         const char bs, const char tl, const char tr,
+                         const char bl, const char br) {
+    ::wborder(m_win.get(), ls, rs, ts, bs, tl, tr, bl, br);
+}
+
+void window::write(const char val) {
+    lock_guard<mutex> lock(m_mtx);
+    if (m_escape_enabled) {
+        if (m_curr_mode != ansi_escape_mode::NONE) {
+            if (val <= 0x40 || val >= 0x7e) {
+                m_escape_args.push(val);
+            } else { // parse escape
+                const ncurses::position tmp = get_curs_pos();
+                switch (val) {
+                case 'A': // CUU
+                    move_curs(
+                        { .x = tmp.x,
+                          .y = tmp.y == 0
+                                   ? 0
+                                   : tmp.y - get_escape_arg(m_escape_args) });
+                    break;
+                case 'B': // CUD
+                    move_curs(
+                        { .x = tmp.x,
+                          .y = tmp.y == m_win->_maxy
+                                   ? tmp.y
+                                   : tmp.y + get_escape_arg(m_escape_args) });
+                    break;
+                case 'C': // CUF
+                    move_curs(
+                        { .x = tmp.x == m_win->_maxx
+                                   ? tmp.x
+                                   : tmp.x + get_escape_arg(m_escape_args),
+                          .y = tmp.y });
+                    break;
+                case 'D': // CUB
+                    move_curs({ .x = tmp.x == 0 ? 0
+                                                : tmp.x - get_escape_arg(
+                                                              m_escape_args),
+                                .y = tmp.y });
+                    break;
+                case 'H': // CUP
+                {
+                    const int row = get_escape_arg(m_escape_args);
+                    const int col = get_escape_arg(m_escape_args);
+                    move_curs({ .x = col, .y = row });
+                } break;
+                case 'J': // ED
+                    switch (get_escape_arg(m_escape_args)) {
+                    case 0:
+                        clear_to_bottom();
+                        break;
+                    case 2:
+                    case 3: // TODO: impl scrollback buffer clearing
+                        clear_screen();
+                        break;
+                    default: // TODO: implement other args
+                        break;
+                    }
+                case 'm': // SGR TODO: implement
+                    break;
+                }
+
+                m_escape_enabled = false;
+                m_escape_args = queue<u8>();
+                m_curr_mode = ansi_escape_mode::NONE;
+            }
+        } else {
+            switch (val) {
+            case '[': // CSI
+                m_curr_mode = ansi_escape_mode::CSI;
+                break;
+            default:
+                break;
+            }
+        }
+    } else {
+        switch (val) {
+        case '\a':
+            return; // ignore
+        case '\e':
+            m_escape_enabled = true;
+            return;
+        case '\n':
+            // custom newline routine
+            newline();
+            break;
+        default:
+            ::waddch(m_win.get(), val);
+            break;
+        }
+    }
+}
+
+void window::write(const std::string& str) {
+    lock_guard<mutex> lock(m_mtx);
+    ::waddnstr(m_win.get(), str.c_str(), str.length());
+}
+
+void window::write(const std::string& str, const position& pos) {
+    lock_guard<mutex> lock(m_mtx);
+    ::wmove(m_win.get(), pos.y, pos.x);
+    ::waddnstr(m_win.get(), str.c_str(), str.length());
+}
+
+void window::write(const std::string& str, const int color) {
+    lock_guard<mutex> lock(m_mtx);
+    ::wcolor_set(m_win.get(), color, 0);
+    ::waddnstr(m_win.get(), str.c_str(), str.length());
+    ::wcolor_set(m_win.get(), FGCOL(colors::WHITE), 0);
+}
+
+void window::set_scrolling(const bool enable) {
+    ::scrollok(m_win.get(), enable);
+}
+
+void window::set_timeout(const int timeout_ms) {
+    ::wtimeout(m_win.get(), timeout_ms);
+}
+
+position window::get_curs_pos() const {
+    return position{ m_win->_curx, m_win->_cury };
+}
+
+void window::move_curs(const position& pos) {
+    ::wmove(m_win.get(), pos.y, pos.x);
+}
+
+void window::refresh() {
+    ::wrefresh(m_win.get());
+}
+
+i8 window::get_char() const {
+    return ::wgetch(m_win.get());
+}
+
+void window::clear_to_bottom() {
+    ::wclrtobot(m_win.get());
+}
+
+void window::clear_screen() {
+    ::wclear(m_win.get());
+}
+
+void window::newline() {
+    if (m_win->_cury == m_win->_maxy) {
+        ::wscrl(m_win.get(), 1);
+    }
+    move_curs({ .x = 0, .y = m_win->_cury + 1 });
+    ::wclrtoeol(m_win.get());
+}
+
+void cleanup_tui() {
+    ::endwin();
+}
+
+terminal::terminal(): m_main_win(initscr()) {
+    ::raw();
+    ::noecho();
+    atexit(&cleanup_tui);
+
+    if (::has_colors()) {
+        ::start_color();
+        for (int fg = 0; fg < 8; fg++) {
+            for (int bg = 0; bg < 8; bg++) {
+                ::init_pair(COLPAIR(fg, bg), fg, bg);
+            }
+        }
+    }
+
+    m_main_win.draw_border('|', '|', '=', '-', '+', '+', '+', '+');
+
+    m_main_win.refresh();
+}
+
+terminal::~terminal() {
+    // nothing to do
+}
+
+dimensions terminal::get_dimensions() {
+    return { ::COLS - 2, ::LINES - 3 };
+}
+
+void terminal::refresh() {
+    ::refresh();
+}
+
+} // namespace ncurses
+} // namespace vcml

--- a/src/vcml/core/setup.cpp
+++ b/src/vcml/core/setup.cpp
@@ -9,6 +9,9 @@
  ******************************************************************************/
 
 #include "vcml/core/setup.h"
+#ifdef HAVE_NCURSES
+#include "vcml/ui/tui.h"
+#endif
 
 #include <locale.h>
 
@@ -74,7 +77,11 @@ setup::setup(int argc, char** argv):
     }
 
     if (m_log_stdout.value() || !m_log_files.has_value()) {
+#ifdef HAVE_NCURSES
+        mwr::publisher* pub = new log_tui(true);
+#else
         mwr::publisher* pub = new mwr::publishers::terminal(true);
+#endif
         pub->set_level(min, max);
         m_publishers.push_back(pub);
     }

--- a/src/vcml/logging/log_tui.cpp
+++ b/src/vcml/logging/log_tui.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2022 MachineWare GmbH                                        *
+ * All Rights Reserved                                                        *
+ *                                                                            *
+ * This is work is licensed under the terms described in the LICENSE file     *
+ * found in the root directory of this source tree.                           *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "vcml/logging/log_tui.h"
+
+namespace vcml {
+
+log_tui::log_tui(bool use_colors): publisher(), m_colors(use_colors) {
+    // nothing to do
+}
+
+void log_tui::publish(const mwr::logmsg& msg) {
+    ncurses::window& win = ui::tui::instance()->get_tui_window();
+
+    stringstream ss;
+    ss << msg << std::endl;
+    if (m_colors) {
+        win.write(ss.str(), COLORS[msg.level]);
+    } else {
+        win.write(ss.str());
+    }
+    win.refresh();
+}
+
+const int log_tui::COLORS[mwr::log_level::NUM_LOG_LEVELS] = {
+    /* [LOG_ERROR] = */ FGCOL(ncurses::colors::RED),
+    /* [LOG_WARN]  = */ FGCOL(ncurses::colors::YELLOW),
+    /* [LOG_INFO]  = */ FGCOL(ncurses::colors::GREEN),
+    /* [LOG_DEBUG] = */ FGCOL(ncurses::colors::BLUE),
+};
+
+} // namespace vcml

--- a/src/vcml/ui/tui.cpp
+++ b/src/vcml/ui/tui.cpp
@@ -1,0 +1,60 @@
+#include "vcml/ui/tui.h"
+
+namespace vcml {
+namespace ui {
+
+void tui::tuithread() {
+    const u64 update_interval = 1000000;
+    u64 last_sim = time_to_us(sc_time_stamp());
+    u64 last_host = mwr::timestamp_us();
+
+    while (sim_running()) {
+        const u64 now_sim = time_to_us(sc_time_stamp());
+        const u64 now_host = mwr::timestamp_us();
+        const u64 delta = now_host - last_host;
+        if (delta >= update_interval) {
+            const double rtf = (double)(now_sim - last_sim) / delta;
+
+            const size_t millis = (now_sim % 1000000) / 1000;
+            const size_t times = now_sim / 1000000;
+            const size_t hours = times / 3600;
+            const size_t minutes = (times % 3600) / 60;
+            const size_t seconds = times % 60;
+
+            string title = mkstr(
+                "+===== time %02zu:%02zu:%02zu.%03zu === delta %lld === rtf "
+                "%.2f ",
+                hours, minutes, seconds, millis, delta, rtf);
+            m_term.get_win().write(title, ncurses::position{ 0, 0 });
+            m_term.refresh();
+            last_sim = now_sim;
+            last_host = now_host;
+        }
+        std::this_thread::sleep_for(
+            std::chrono::microseconds(update_interval));
+    }
+}
+
+tui* tui::tui_instance = nullptr;
+
+tui::tui():
+    m_term(),
+    m_tui_window(m_term.get_dimensions(), ncurses::position{ 1, 1 }),
+    m_tui_thread(&tui::tuithread, this) {
+    tui_instance = this;
+    mwr::set_thread_name(m_tui_thread, "tui_thread");
+}
+
+tui* tui::instance() {
+    if (!tui_instance) {
+        tui_instance = new tui;
+    }
+    return tui_instance;
+}
+
+ncurses::window& tui::get_tui_window() {
+    return m_tui_window;
+}
+
+} // namespace ui
+} // namespace vcml


### PR DESCRIPTION
This adds a TUI based on ncurses to VCML.

You (currently) need to build your VP with `-DDISABLE_COPYRIGHT_MESSAGE=1` so that SystemCs copyright header printing does not interfere with the TUI.

Currently implemented:
- Status header in TUI
- Log output to TUI
- TUI backend for serial model

ToDos:
- Expand ANSI capabilities of TUI serial backend
- Tracing output in TUI mode
- ...

Ideas:
- Separate ncurses windows for logging/tracing output