### PR TITLE
Use hierarchy guard when creating event

### DIFF
--- a/include/vcml/protocols/tlm_sockets.h
+++ b/include/vcml/protocols/tlm_sockets.h
@@ -304,8 +304,10 @@ public:
 };
 
 inline void tlm_target_socket::wait_free() {
-    if (!m_free_ev)
+    if (!m_free_ev) {
+        hierarchy_guard guard(this);
         m_free_ev = new sc_event(strcat(basename(), "_free").c_str());
+    }
     sc_core::wait(*m_free_ev);
 }
 


### PR DESCRIPTION
When the free event is created, use a hierarchy guard to create the event as a child of the tlm_socket in the SystemC module hierarchy.