### PR TITLE
pl330: fix decoding of Channel Control Registers

### DIFF
--- a/src/vcml/models/dma/pl330.cpp
+++ b/src/vcml/models/dma/pl330.cpp
@@ -408,12 +408,14 @@ static void pl330_insn_dmamov(pl330* dma, pl330::channel* ch, u8 opcode,
     u32 im = (((u32)args[4]) << 24) | (((u32)args[3]) << 16) |
              (((u32)args[2]) << 8) | (((u32)args[1]));
 
+    bool src_secure = !(im & (2 << 8 ));
+    bool dst_secure = !(im & (2 << 22));
     switch (rd) {
     case 0b000:
         ch->sar = im;
         break;
     case 0b001:
-        if (!(im & (0x9 << 10)) && (ch->csr & CSR_CNS)) {
+        if ((src_secure || dst_secure)  && (ch->csr & CSR_CNS)) {
             pl330_handle_ch_fault(*dma, *ch, FTR_CH_RDWR_ERR);
             break;
         }


### PR DESCRIPTION

A DMAMOV CCR instruction produced a fault. The decoding of the secure state bits used the wrong bits IMHO.

see:

https://developer.arm.com/documentation/ddi0424/c/instruction-set/assembler-directives/dmamov-ccr?lang=en

and table 3.21:

https://developer.arm.com/documentation/ddi0424/c/programmers-model/register-descriptions/channel-control-registers?lang=en

[24:22]	dst_prot_ctrl
and
[10:8]	src_prot_ctrl

should be the relevant bits.
