### PR TITLE
gdbserver deadlock

### DIFF
--- a/src/vcml/debugging/gdbserver.cpp
+++ b/src/vcml/debugging/gdbserver.cpp
@@ -96,7 +96,10 @@ void gdbserver::update_status(gdb_status status, gdb_target* gtgt,
             m_hit_wp_addr = wp_addr;
             m_hit_wp_type = wp_type;
         }
+
+        m_mtx.unlock();
         suspend(true);
+        m_mtx.lock();
         break;
 
     case GDB_RUNNING:


### PR DESCRIPTION
We seem to have a deadlock in gdbserver, when a user tries to stop simulation via CTRL-C, while the simulation hits a breakpoint at the same time:

* SystemC thread: encounters a breakpoint and wants to pause the GDB server (has SystemC mtx, wants GDB mtx)
* GDB thread: receives a user stop requests and wants to pause the GDB server (has GDB mtx, wants SystemC mtx)