### PR TITLE
Sort regs of gdbserver target by regno

### DIFF
--- a/src/vcml/debugging/gdbarch.cpp
+++ b/src/vcml/debugging/gdbarch.cpp
@@ -29,6 +29,11 @@ bool gdbfeature::collect_regs(const target& t, vector<const cpureg*>& regs,
         }
     }
 
+    std::sort(regs.begin(), regs.end(),
+              [](const cpureg* a, const cpureg* b) -> bool {
+                  return a->regno < b->regno;
+              });
+
     return missing.empty();
 }
 


### PR DESCRIPTION
For the `reg_read_all` command, the gdb client expects the order of the reg values to be the same as the order of the reg IDs. The `handle_reg_read_all` function sends the values in the order of the cpuregs vector of the target, which is ordered by the order of the gdbarch feature struct.
To solve this issue, the cpuregs vector is sorted based on the reg IDs.