### PR TITLE
CI: Unity builds & more

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -49,7 +49,7 @@ jobs:
       run: ./utils/setup-systemc -p ${{github.workspace}} -v ${{matrix.systemc}}
 
     - name: Configure
-      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{matrix.sanitizer}} -DVCML_BUILD_TESTS=ON
+      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{matrix.sanitizer}} -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=ON
 
     - name: Build
       run: cmake --build BUILD

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -67,7 +67,7 @@ jobs:
       run: ./utils/setup-systemc -p ${{github.workspace}} -v ${{matrix.systemc}}
 
     - name: Configure
-      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON
+      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=ON
 
     - name: Build
       run: cmake --build BUILD

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
       run: ./utils/setup-systemc -p ${{github.workspace}} -v ${{matrix.systemc}}
 
     - name: Configure Project
-      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_COVERAGE=ON -DVCML_BUILD_TESTS=ON
+      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_COVERAGE=ON -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=ON
 
     - name: Build Project
       run: cmake --build BUILD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       run: ./utils/setup-systemc -p ${{github.workspace}} -v ${{matrix.systemc}}
 
     - name: Configure
-      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON -DVCML_LINTER=clang-tidy
+      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON -DVCML_LINTER=clang-tidy -DVCML_UNITY_BUILD=ON
 
     - name: Build
       run: cmake --build BUILD

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
       run: ./utils/setup-systemc -p ${{github.workspace}} -v ${{matrix.systemc}}
 
     - name: Configure
-      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON
+      run: cmake -G Ninja -B BUILD -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=ON
 
     - name: Build
       run: cmake --build BUILD

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Configure
-      run: cmake -B BUILD -DCMAKE_BUILD_TYPE=${{matrix.cfg}} -DVCML_BUILD_TESTS=ON
+      run: cmake -B BUILD -DCMAKE_BUILD_TYPE=${{matrix.cfg}} -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=OFF
 
     - name: Build
       run: cmake --build BUILD --config ${{matrix.cfg}} -- /bl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         cfg: [Release]
 
     steps:
@@ -27,7 +27,7 @@ jobs:
       run: cmake -B BUILD -DCMAKE_BUILD_TYPE=${{matrix.cfg}} -DVCML_BUILD_TESTS=ON -DVCML_UNITY_BUILD=OFF
 
     - name: Build
-      run: cmake --build BUILD --config ${{matrix.cfg}} -- /bl
+      run: cmake --build BUILD --config ${{matrix.cfg}} --parallel -- /bl
 
     - name: Test
       working-directory: BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
  #                                                                            #
  ##############################################################################
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.16)
 project(vcml VERSION 2025.05.14 LANGUAGES C CXX)
 
 option(VCML_USE_SDL2 "Use SDL2 for rendering" ON)
@@ -20,6 +20,7 @@ option(VCML_USE_USB "Use LibUSB for host USB devices" ON)
 option(VCML_BUILD_TESTS "Build unit tests" OFF)
 option(VCML_BUILD_UTILS "Build utility programs" ON)
 option(VCML_COVERAGE "Enable generation of code coverage data" OFF)
+option(VCML_UNITY_BUILD "Enable unity build" OFF)
 set(VCML_LINTER "" CACHE STRING "Code linter to use")
 
 include(cmake/common.cmake)
@@ -203,6 +204,14 @@ if(MSVC)
     target_sources(vcml PRIVATE ${src}/vcml/protocols/tlm_memory_win32.cpp)
 else()
     target_sources(vcml PRIVATE ${src}/vcml/protocols/tlm_memory_posix.cpp)
+endif()
+
+if(VCML_UNITY_BUILD)
+    message(STATUS "Enable VCML unity build")
+    set_target_properties(vcml PROPERTIES UNITY_BUILD ON)
+    set_source_files_properties(${src}/vcml/core/setup.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+else()
+    message(STATUS "Disable VCML unity build")
 endif()
 
 set_target_properties(vcml PROPERTIES DEBUG_POSTFIX "d")

--- a/include/vcml/models/serial/backend.h
+++ b/include/vcml/models/serial/backend.h
@@ -17,6 +17,12 @@
 namespace vcml {
 namespace serial {
 
+enum keys : u8 {
+    CTRL_A = 0x1,
+    CTRL_C = 0x3,
+    CTRL_X = 0x18,
+};
+
 class terminal;
 
 class backend

--- a/src/vcml/core/processor.cpp
+++ b/src/vcml/core/processor.cpp
@@ -10,18 +10,14 @@
 
 #include "vcml/core/processor.h"
 
-#define HEX(x, w)                                                  \
-    std::setfill('0') << std::setw(w) << std::hex << x << std::dec \
-                      << std::setfill(' ')
-
 namespace vcml {
 
 bool processor::cmd_dump(const vector<string>& args, ostream& os) {
     os << "Registers:" << std::endl
-       << "  PC 0x" << HEX(program_counter(), 16) << std::endl
-       << "  LR 0x" << HEX(link_register(), 16) << std::endl
-       << "  SP 0x" << HEX(stack_pointer(), 16) << std::endl
-       << "  ID 0x" << HEX(core_id(), 16) << std::endl;
+       << "  PC 0x" << mkstr("%0*llx", 16, program_counter()) << std::endl
+       << "  LR 0x" << mkstr("%0*llx", 16, link_register()) << std::endl
+       << "  SP 0x" << mkstr("%0*llx", 16, stack_pointer()) << std::endl
+       << "  ID 0x" << mkstr("%0*llx", 16, core_id()) << std::endl;
 
     os << "Interrupts:" << std::endl;
     for (auto it : irq) {
@@ -64,16 +60,17 @@ bool processor::cmd_read(const vector<string>& args, ostream& os) {
         return false;
     }
 
-    os << "reading range 0x" << HEX(start, 16) << " .. 0x" << HEX(end, 16);
+    os << "reading range 0x" << mkstr("%0*llx\n", 16, start) << " .. 0x"
+       << mkstr("%0*llx", 16, end);
 
     u64 addr = start & ~0xf;
     while (addr < end) {
         if ((addr % 16) == 0)
-            os << "\n" << HEX(addr, 16) << ":";
+            os << "\n" << mkstr("%0*llx", 16, addr) << ":";
         if ((addr % 4) == 0)
             os << " ";
         if (addr >= start)
-            os << HEX((unsigned int)data[addr - start], 2);
+            os << mkstr("%0*x", 2, (unsigned int)data[addr - start]);
         else
             os << "  ";
         addr++;

--- a/src/vcml/models/generic/memory.cpp
+++ b/src/vcml/models/generic/memory.cpp
@@ -20,24 +20,19 @@ bool memory::cmd_show(const vector<string>& args, ostream& os) {
     if ((end <= start) || (end >= size))
         return false;
 
-#define HEX(x, w) \
-    std::setfill('0') << std::setw(w) << std::hex << x << std::dec
-    os << "showing range 0x" << HEX(start, 8) << " .. 0x" << HEX(end, 8);
-
     u64 addr = start & ~0xf;
     while (addr < end) {
         if ((addr % 16) == 0)
-            os << "\n" << HEX(addr, 8) << ":";
+            os << "\n" << mkstr("%0*llx", 8, addr) << ":";
         if ((addr % 4) == 0)
             os << " ";
         if (addr >= start)
-            os << HEX((unsigned int)m_memory[addr], 2) << " ";
+            os << mkstr("%0*x", 2, (unsigned int)m_memory[addr]) << " ";
         else
             os << "   ";
         addr++;
     }
 
-#undef HEX
     return true;
 }
 

--- a/src/vcml/models/serial/backend_term.cpp
+++ b/src/vcml/models/serial/backend_term.cpp
@@ -16,12 +16,6 @@
 namespace vcml {
 namespace serial {
 
-enum keys : u8 {
-    CTRL_A = 0x1,
-    CTRL_C = 0x3,
-    CTRL_X = 0x18,
-};
-
 void backend_term::terminate() {
     if (m_exit_requested || !sim_running()) {
         log_info("forced exit");

--- a/src/vcml/models/serial/backend_tui.cpp
+++ b/src/vcml/models/serial/backend_tui.cpp
@@ -32,12 +32,6 @@ static void update_window_size(int sig) {
 namespace vcml {
 namespace serial {
 
-enum keys : u8 {
-    CTRL_A = 0x1,
-    CTRL_C = 0x3,
-    CTRL_X = 0x18,
-};
-
 void backend_tui::terminate() {
     if (m_exit_requested || !sim_running()) {
         log_info("forced exit");

--- a/src/vcml/models/usb/drive.cpp
+++ b/src/vcml/models/usb/drive.cpp
@@ -68,7 +68,7 @@ static const device_desc DRIVE_DESC{
     },
 };
 
-static const u8 USB3_ENDPOINT_COMPANION_DT[] = {
+static const u8 USB3_ENDPOINT_COMPANION_DT_DRV[] = {
     0x06, // length
     USB_DT_ENDPOINT_COMPANION,
     0x0f, // max burst
@@ -300,7 +300,7 @@ drive::drive(const sc_module_name& nm, const string& img, bool ro, bool wi):
         m_desc.max_packet_size0 = 9;
         for (auto& epdesc : m_desc.configs[0].interfaces[0].endpoints) {
             epdesc.max_packet_size = 1024;
-            for (auto ch : USB3_ENDPOINT_COMPANION_DT)
+            for (auto ch : USB3_ENDPOINT_COMPANION_DT_DRV)
                 epdesc.extra.push_back(ch);
         }
     }

--- a/src/vcml/models/usb/keyboard.cpp
+++ b/src/vcml/models/usb/keyboard.cpp
@@ -70,7 +70,7 @@ static const device_desc KEYBOARD_DESC{
     },
 };
 
-static const u8 USB3_ENDPOINT_COMPANION_DT[] = {
+static const u8 USB3_ENDPOINT_COMPANION_DT_KBD[] = {
     0x06, // length
     USB_DT_ENDPOINT_COMPANION,
     0x00, // max burst
@@ -238,7 +238,7 @@ keyboard::keyboard(const sc_module_name& nm):
         m_desc.bcd_usb = 0x300;
         m_desc.max_packet_size0 = 9;
         auto& extra = m_desc.configs[0].interfaces[0].endpoints[0].extra;
-        for (auto ch : USB3_ENDPOINT_COMPANION_DT)
+        for (auto ch : USB3_ENDPOINT_COMPANION_DT_KBD)
             extra.push_back(ch);
     }
 }

--- a/src/vcml/protocols/can.cpp
+++ b/src/vcml/protocols/can.cpp
@@ -168,23 +168,23 @@ can_target_stub::can_target_stub(const char* nm):
     can_rx.bind(*this);
 }
 
-static can_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static can_base_initiator_socket* can_get_initiator_socket(sc_object* port) {
     return dynamic_cast<can_base_initiator_socket*>(port);
 }
 
-static can_base_target_socket* get_target_socket(sc_object* port) {
+static can_base_target_socket* can_get_target_socket(sc_object* port) {
     return dynamic_cast<can_base_target_socket*>(port);
 }
 
-static can_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static can_base_initiator_socket* can_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<can_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static can_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static can_base_target_socket* can_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<can_base_target_socket>(idx, true);
     return nullptr;
@@ -194,7 +194,7 @@ can_base_initiator_socket& can_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = can_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -203,7 +203,7 @@ can_base_initiator_socket& can_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = can_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -212,7 +212,7 @@ can_base_target_socket& can_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = can_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -221,7 +221,7 @@ can_base_target_socket& can_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = can_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -230,8 +230,8 @@ void can_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = can_get_initiator_socket(child);
+    auto* tgt = can_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid can socket", child->name());
@@ -246,13 +246,13 @@ void can_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    can_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    can_base_initiator_socket* isock = can_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    can_base_target_socket* tsock = get_target_socket(child, idx);
+    can_base_target_socket* tsock = can_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -269,10 +269,10 @@ void can_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = can_get_initiator_socket(p1);
+    auto* i2 = can_get_initiator_socket(p2);
+    auto* t1 = can_get_target_socket(p1);
+    auto* t2 = can_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid can port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid can port", p2->name());
@@ -295,10 +295,10 @@ void can_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = can_get_initiator_socket(p1);
+    auto* i2 = can_get_initiator_socket(p2, idx2);
+    auto* t1 = can_get_target_socket(p1);
+    auto* t2 = can_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid can port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid can port", p2->name());
@@ -321,10 +321,10 @@ void can_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = can_get_initiator_socket(p1, idx1);
+    auto* i2 = can_get_initiator_socket(p2);
+    auto* t1 = can_get_target_socket(p1, idx1);
+    auto* t2 = can_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid can port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid can port", p2->name());
@@ -347,10 +347,10 @@ void can_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = can_get_initiator_socket(p1, idx1);
+    auto* i2 = can_get_initiator_socket(p2, idx2);
+    auto* t1 = can_get_target_socket(p1, idx1);
+    auto* t2 = can_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid can port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid can port", p2->name());

--- a/src/vcml/protocols/clk.cpp
+++ b/src/vcml/protocols/clk.cpp
@@ -170,23 +170,23 @@ clk_target_stub::clk_target_stub(const char* nm):
     clk_in.bind(*(clk_fw_transport_if*)this);
 }
 
-static clk_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static clk_base_initiator_socket* clk_get_initiator_socket(sc_object* port) {
     return dynamic_cast<clk_base_initiator_socket*>(port);
 }
 
-static clk_base_target_socket* get_target_socket(sc_object* port) {
+static clk_base_target_socket* clk_get_target_socket(sc_object* port) {
     return dynamic_cast<clk_base_target_socket*>(port);
 }
 
-static clk_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static clk_base_initiator_socket* clk_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<clk_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static clk_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static clk_base_target_socket* clk_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<clk_base_target_socket>(idx, true);
     return nullptr;
@@ -196,7 +196,7 @@ clk_base_initiator_socket& clk_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = clk_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -205,7 +205,7 @@ clk_base_initiator_socket& clk_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = clk_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -214,7 +214,7 @@ clk_base_target_socket& clk_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = clk_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -223,7 +223,7 @@ clk_base_target_socket& clk_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = clk_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -232,8 +232,8 @@ void clk_stub(const sc_object& obj, const string& port, hz_t hz) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = clk_get_initiator_socket(child);
+    auto* tgt = clk_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid clk socket", child->name());
@@ -248,13 +248,13 @@ void clk_stub(const sc_object& obj, const string& port, size_t idx, hz_t hz) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    clk_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    clk_base_initiator_socket* isock = clk_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    clk_base_target_socket* tsock = get_target_socket(child, idx);
+    clk_base_target_socket* tsock = clk_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub(hz);
         return;
@@ -271,10 +271,10 @@ void clk_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = clk_get_initiator_socket(p1);
+    auto* i2 = clk_get_initiator_socket(p2);
+    auto* t1 = clk_get_target_socket(p1);
+    auto* t2 = clk_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid clk port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid clk port", p2->name());
@@ -297,10 +297,10 @@ void clk_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = clk_get_initiator_socket(p1);
+    auto* i2 = clk_get_initiator_socket(p2, idx2);
+    auto* t1 = clk_get_target_socket(p1);
+    auto* t2 = clk_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid clk port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid clk port", p2->name());
@@ -323,10 +323,10 @@ void clk_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = clk_get_initiator_socket(p1, idx1);
+    auto* i2 = clk_get_initiator_socket(p2);
+    auto* t1 = clk_get_target_socket(p1, idx1);
+    auto* t2 = clk_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid clk port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid clk port", p2->name());
@@ -349,10 +349,10 @@ void clk_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = clk_get_initiator_socket(p1, idx1);
+    auto* i2 = clk_get_initiator_socket(p2, idx2);
+    auto* t1 = clk_get_target_socket(p1, idx1);
+    auto* t2 = clk_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid clk port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid clk port", p2->name());

--- a/src/vcml/protocols/eth.cpp
+++ b/src/vcml/protocols/eth.cpp
@@ -460,23 +460,23 @@ eth_target_stub::eth_target_stub(const char* nm):
     eth_rx.bind(*this);
 }
 
-static eth_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static eth_base_initiator_socket* eth_get_initiator_socket(sc_object* port) {
     return dynamic_cast<eth_base_initiator_socket*>(port);
 }
 
-static eth_base_target_socket* get_target_socket(sc_object* port) {
+static eth_base_target_socket* eth_get_target_socket(sc_object* port) {
     return dynamic_cast<eth_base_target_socket*>(port);
 }
 
-static eth_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static eth_base_initiator_socket* eth_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<eth_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static eth_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static eth_base_target_socket* eth_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<eth_base_target_socket>(idx, true);
     return nullptr;
@@ -486,7 +486,7 @@ eth_base_initiator_socket& eth_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = eth_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -495,7 +495,7 @@ eth_base_initiator_socket& eth_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = eth_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -504,7 +504,7 @@ eth_base_target_socket& eth_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = eth_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -513,7 +513,7 @@ eth_base_target_socket& eth_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = eth_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -522,8 +522,8 @@ void eth_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = eth_get_initiator_socket(child);
+    auto* tgt = eth_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid ethernet socket", child->name());
@@ -538,13 +538,13 @@ void eth_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    eth_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    eth_base_initiator_socket* isock = eth_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    eth_base_target_socket* tsock = get_target_socket(child, idx);
+    eth_base_target_socket* tsock = eth_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -561,10 +561,10 @@ void eth_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = eth_get_initiator_socket(p1);
+    auto* i2 = eth_get_initiator_socket(p2);
+    auto* t1 = eth_get_target_socket(p1);
+    auto* t2 = eth_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid ethernet port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid ethernet port", p2->name());
@@ -587,10 +587,10 @@ void eth_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = eth_get_initiator_socket(p1);
+    auto* i2 = eth_get_initiator_socket(p2, idx2);
+    auto* t1 = eth_get_target_socket(p1);
+    auto* t2 = eth_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid ethernet port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid ethernet port", p2->name());
@@ -613,10 +613,10 @@ void eth_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = eth_get_initiator_socket(p1, idx1);
+    auto* i2 = eth_get_initiator_socket(p2);
+    auto* t1 = eth_get_target_socket(p1, idx1);
+    auto* t2 = eth_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid ethernet port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid ethernet port", p2->name());
@@ -639,10 +639,10 @@ void eth_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = eth_get_initiator_socket(p1, idx1);
+    auto* i2 = eth_get_initiator_socket(p2, idx2);
+    auto* t1 = eth_get_target_socket(p1, idx1);
+    auto* t2 = eth_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid ethernet port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid ethernet port", p2->name());

--- a/src/vcml/protocols/gpio.cpp
+++ b/src/vcml/protocols/gpio.cpp
@@ -311,23 +311,23 @@ void gpio_target_adapter::gpio_transport(const gpio_target_socket& socket,
     m_trigger.notify(SC_ZERO_TIME);
 }
 
-static gpio_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static gpio_base_initiator_socket* gpio_get_initiator_socket(sc_object* port) {
     return dynamic_cast<gpio_base_initiator_socket*>(port);
 }
 
-static gpio_base_target_socket* get_target_socket(sc_object* port) {
+static gpio_base_target_socket* gpio_get_target_socket(sc_object* port) {
     return dynamic_cast<gpio_base_target_socket*>(port);
 }
 
-static gpio_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                        size_t idx) {
+static gpio_base_initiator_socket* gpio_get_initiator_socket(sc_object* array,
+                                                             size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<gpio_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static gpio_base_target_socket* get_target_socket(sc_object* array,
-                                                  size_t idx) {
+static gpio_base_target_socket* gpio_get_target_socket(sc_object* array,
+                                                       size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<gpio_base_target_socket>(idx, true);
     return nullptr;
@@ -337,7 +337,7 @@ gpio_base_initiator_socket& gpio_initiator(const sc_object& parent,
                                            const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = gpio_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -346,7 +346,7 @@ gpio_base_initiator_socket& gpio_initiator(const sc_object& parent,
                                            const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = gpio_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -355,7 +355,7 @@ gpio_base_target_socket& gpio_target(const sc_object& parent,
                                      const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = gpio_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -364,7 +364,7 @@ gpio_base_target_socket& gpio_target(const sc_object& parent,
                                      const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = gpio_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -373,8 +373,8 @@ void gpio_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = gpio_get_initiator_socket(child);
+    auto* tgt = gpio_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid gpio socket", child->name());
@@ -389,13 +389,13 @@ void gpio_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    gpio_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    gpio_base_initiator_socket* isock = gpio_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    gpio_base_target_socket* tsock = get_target_socket(child, idx);
+    gpio_base_target_socket* tsock = gpio_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -412,10 +412,10 @@ void gpio_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = gpio_get_initiator_socket(p1);
+    auto* i2 = gpio_get_initiator_socket(p2);
+    auto* t1 = gpio_get_target_socket(p1);
+    auto* t2 = gpio_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid gpio port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid gpio port", p2->name());
@@ -438,10 +438,10 @@ void gpio_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = gpio_get_initiator_socket(p1);
+    auto* i2 = gpio_get_initiator_socket(p2, idx2);
+    auto* t1 = gpio_get_target_socket(p1);
+    auto* t2 = gpio_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid gpio port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid gpio port", p2->name());
@@ -464,10 +464,10 @@ void gpio_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = gpio_get_initiator_socket(p1, idx1);
+    auto* i2 = gpio_get_initiator_socket(p2);
+    auto* t1 = gpio_get_target_socket(p1, idx1);
+    auto* t2 = gpio_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid gpio port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid gpio port", p2->name());
@@ -490,10 +490,10 @@ void gpio_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = gpio_get_initiator_socket(p1, idx1);
+    auto* i2 = gpio_get_initiator_socket(p2, idx2);
+    auto* t1 = gpio_get_target_socket(p1, idx1);
+    auto* t2 = gpio_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid gpio port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid gpio port", p2->name());
@@ -513,8 +513,8 @@ void gpio_bind(const sc_object& obj, const string& port,
     auto* p = find_child(obj, port);
     VCML_ERROR_ON(!p, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* i = get_initiator_socket(p);
-    auto* t = get_target_socket(p);
+    auto* i = gpio_get_initiator_socket(p);
+    auto* t = gpio_get_target_socket(p);
 
     VCML_ERROR_ON(!i && !t, "%s is not a valid gpio port", p->name());
 
@@ -529,8 +529,8 @@ void gpio_bind(const sc_object& obj, const string& port, size_t idx,
     auto* p = find_child(obj, port);
     VCML_ERROR_ON(!p, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* i = get_initiator_socket(p, idx);
-    auto* t = get_target_socket(p, idx);
+    auto* i = gpio_get_initiator_socket(p, idx);
+    auto* t = gpio_get_target_socket(p, idx);
 
     VCML_ERROR_ON(!i && !t, "%s is not a valid gpio port", p->name());
 

--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -218,23 +218,23 @@ i2c_target_stub::i2c_target_stub(const char* nm):
     i2c_in.bind(*this);
 }
 
-static i2c_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static i2c_base_initiator_socket* i2c_get_initiator_socket(sc_object* port) {
     return dynamic_cast<i2c_base_initiator_socket*>(port);
 }
 
-static i2c_base_target_socket* get_target_socket(sc_object* port) {
+static i2c_base_target_socket* i2c_get_target_socket(sc_object* port) {
     return dynamic_cast<i2c_base_target_socket*>(port);
 }
 
-static i2c_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static i2c_base_initiator_socket* i2c_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<i2c_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static i2c_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static i2c_base_target_socket* i2c_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<i2c_base_target_socket>(idx, true);
     return nullptr;
@@ -244,7 +244,7 @@ i2c_base_initiator_socket& i2c_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = i2c_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -253,7 +253,7 @@ i2c_base_initiator_socket& i2c_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = i2c_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -262,7 +262,7 @@ i2c_base_target_socket& i2c_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = i2c_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -271,7 +271,7 @@ i2c_base_target_socket& i2c_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = i2c_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -298,8 +298,8 @@ void i2c_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = i2c_get_initiator_socket(child);
+    auto* tgt = i2c_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid i2c socket", child->name());
@@ -314,13 +314,13 @@ void i2c_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    i2c_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    i2c_base_initiator_socket* isock = i2c_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    i2c_base_target_socket* tsock = get_target_socket(child, idx);
+    i2c_base_target_socket* tsock = i2c_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -337,10 +337,10 @@ void i2c_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = i2c_get_initiator_socket(p1);
+    auto* i2 = i2c_get_initiator_socket(p2);
+    auto* t1 = i2c_get_target_socket(p1);
+    auto* t2 = i2c_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid i2c port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid i2c port", p2->name());
@@ -363,10 +363,10 @@ void i2c_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = i2c_get_initiator_socket(p1);
+    auto* i2 = i2c_get_initiator_socket(p2, idx2);
+    auto* t1 = i2c_get_target_socket(p1);
+    auto* t2 = i2c_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid i2c port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid i2c port", p2->name());
@@ -389,10 +389,10 @@ void i2c_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = i2c_get_initiator_socket(p1, idx1);
+    auto* i2 = i2c_get_initiator_socket(p2);
+    auto* t1 = i2c_get_target_socket(p1, idx1);
+    auto* t2 = i2c_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid i2c port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid i2c port", p2->name());
@@ -415,10 +415,10 @@ void i2c_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = i2c_get_initiator_socket(p1, idx1);
+    auto* i2 = i2c_get_initiator_socket(p2, idx2);
+    auto* t1 = i2c_get_target_socket(p1, idx1);
+    auto* t2 = i2c_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid i2c port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid i2c port", p2->name());

--- a/src/vcml/protocols/pci.cpp
+++ b/src/vcml/protocols/pci.cpp
@@ -320,23 +320,23 @@ pci_target_stub::pci_target_stub(const char* nm):
     pci_in.bind(*this);
 }
 
-static pci_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static pci_base_initiator_socket* pci_get_initiator_socket(sc_object* port) {
     return dynamic_cast<pci_base_initiator_socket*>(port);
 }
 
-static pci_base_target_socket* get_target_socket(sc_object* port) {
+static pci_base_target_socket* pci_get_target_socket(sc_object* port) {
     return dynamic_cast<pci_base_target_socket*>(port);
 }
 
-static pci_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static pci_base_initiator_socket* pci_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<pci_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static pci_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static pci_base_target_socket* pci_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<pci_base_target_socket>(idx, true);
     return nullptr;
@@ -346,8 +346,8 @@ void pci_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = pci_get_initiator_socket(child);
+    auto* tgt = pci_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid pci socket", child->name());
@@ -362,13 +362,13 @@ void pci_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    pci_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    pci_base_initiator_socket* isock = pci_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    pci_base_target_socket* tsock = get_target_socket(child, idx);
+    pci_base_target_socket* tsock = pci_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -385,10 +385,10 @@ void pci_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = pci_get_initiator_socket(p1);
+    auto* i2 = pci_get_initiator_socket(p2);
+    auto* t1 = pci_get_target_socket(p1);
+    auto* t2 = pci_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid pci port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid pci port", p2->name());
@@ -411,10 +411,10 @@ void pci_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = pci_get_initiator_socket(p1);
+    auto* i2 = pci_get_initiator_socket(p2, idx2);
+    auto* t1 = pci_get_target_socket(p1);
+    auto* t2 = pci_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid pci port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid pci port", p2->name());
@@ -437,10 +437,10 @@ void pci_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = pci_get_initiator_socket(p1, idx1);
+    auto* i2 = pci_get_initiator_socket(p2);
+    auto* t1 = pci_get_target_socket(p1, idx1);
+    auto* t2 = pci_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid pci port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid pci port", p2->name());
@@ -463,10 +463,10 @@ void pci_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = pci_get_initiator_socket(p1, idx1);
+    auto* i2 = pci_get_initiator_socket(p2, idx2);
+    auto* t1 = pci_get_target_socket(p1, idx1);
+    auto* t2 = pci_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid pci port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid pci port", p2->name());

--- a/src/vcml/protocols/sd.cpp
+++ b/src/vcml/protocols/sd.cpp
@@ -381,22 +381,23 @@ sd_target_stub::sd_target_stub(const char* nm):
     sd_in.bind(*this);
 }
 
-static sd_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static sd_base_initiator_socket* sd_get_initiator_socket(sc_object* port) {
     return dynamic_cast<sd_base_initiator_socket*>(port);
 }
 
-static sd_base_target_socket* get_target_socket(sc_object* port) {
+static sd_base_target_socket* sd_get_target_socket(sc_object* port) {
     return dynamic_cast<sd_base_target_socket*>(port);
 }
 
-static sd_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                      size_t idx) {
+static sd_base_initiator_socket* sd_get_initiator_socket(sc_object* array,
+                                                         size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<sd_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static sd_base_target_socket* get_target_socket(sc_object* array, size_t idx) {
+static sd_base_target_socket* sd_get_target_socket(sc_object* array,
+                                                   size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<sd_base_target_socket>(idx, true);
     return nullptr;
@@ -406,7 +407,7 @@ sd_base_initiator_socket& sd_initiator(const sc_object& parent,
                                        const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = sd_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -415,7 +416,7 @@ sd_base_initiator_socket& sd_initiator(const sc_object& parent,
                                        const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = sd_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -423,7 +424,7 @@ sd_base_initiator_socket& sd_initiator(const sc_object& parent,
 sd_base_target_socket& sd_target(const sc_object& parent, const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = sd_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -432,7 +433,7 @@ sd_base_target_socket& sd_target(const sc_object& parent, const string& port,
                                  size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = sd_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -441,8 +442,8 @@ void sd_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = sd_get_initiator_socket(child);
+    auto* tgt = sd_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid sd socket", child->name());
@@ -457,13 +458,13 @@ void sd_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    sd_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    sd_base_initiator_socket* isock = sd_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    sd_base_target_socket* tsock = get_target_socket(child, idx);
+    sd_base_target_socket* tsock = sd_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -480,10 +481,10 @@ void sd_bind(const sc_object& obj1, const string& port1, const sc_object& obj2,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = sd_get_initiator_socket(p1);
+    auto* i2 = sd_get_initiator_socket(p2);
+    auto* t1 = sd_get_target_socket(p1);
+    auto* t2 = sd_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid sd port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid sd port", p2->name());
@@ -506,10 +507,10 @@ void sd_bind(const sc_object& obj1, const string& port1, const sc_object& obj2,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = sd_get_initiator_socket(p1);
+    auto* i2 = sd_get_initiator_socket(p2, idx2);
+    auto* t1 = sd_get_target_socket(p1);
+    auto* t2 = sd_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid sd port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid sd port", p2->name());
@@ -532,10 +533,10 @@ void sd_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = sd_get_initiator_socket(p1, idx1);
+    auto* i2 = sd_get_initiator_socket(p2);
+    auto* t1 = sd_get_target_socket(p1, idx1);
+    auto* t2 = sd_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid sd port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid sd port", p2->name());
@@ -558,10 +559,10 @@ void sd_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = sd_get_initiator_socket(p1, idx1);
+    auto* i2 = sd_get_initiator_socket(p2, idx2);
+    auto* t1 = sd_get_target_socket(p1, idx1);
+    auto* t2 = sd_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid sd port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid sd port", p2->name());

--- a/src/vcml/protocols/serial.cpp
+++ b/src/vcml/protocols/serial.cpp
@@ -235,23 +235,24 @@ serial_target_stub::serial_target_stub(const char* nm):
     serial_rx.bind(*this);
 }
 
-static serial_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static serial_base_initiator_socket* serial_get_initiator_socket(
+    sc_object* port) {
     return dynamic_cast<serial_base_initiator_socket*>(port);
 }
 
-static serial_base_target_socket* get_target_socket(sc_object* port) {
+static serial_base_target_socket* serial_get_target_socket(sc_object* port) {
     return dynamic_cast<serial_base_target_socket*>(port);
 }
 
-static serial_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                          size_t idx) {
+static serial_base_initiator_socket* serial_get_initiator_socket(
+    sc_object* array, size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<serial_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static serial_base_target_socket* get_target_socket(sc_object* array,
-                                                    size_t idx) {
+static serial_base_target_socket* serial_get_target_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<serial_base_target_socket>(idx, true);
     return nullptr;
@@ -261,7 +262,7 @@ serial_base_initiator_socket& serial_initiator(const sc_object& parent,
                                                const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = serial_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -271,7 +272,7 @@ serial_base_initiator_socket& serial_initiator(const sc_object& parent,
                                                size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = serial_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -280,7 +281,7 @@ serial_base_target_socket& serial_target(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = serial_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -289,7 +290,7 @@ serial_base_target_socket& serial_target(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = serial_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -298,8 +299,8 @@ void serial_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = serial_get_initiator_socket(child);
+    auto* tgt = serial_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid serial socket", child->name());
@@ -314,13 +315,14 @@ void serial_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    serial_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    serial_base_initiator_socket* isock = serial_get_initiator_socket(child,
+                                                                      idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    serial_base_target_socket* tsock = get_target_socket(child, idx);
+    serial_base_target_socket* tsock = serial_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -337,10 +339,10 @@ void serial_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = serial_get_initiator_socket(p1);
+    auto* i2 = serial_get_initiator_socket(p2);
+    auto* t1 = serial_get_target_socket(p1);
+    auto* t2 = serial_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid serial port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid serial port", p2->name());
@@ -363,10 +365,10 @@ void serial_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = serial_get_initiator_socket(p1);
+    auto* i2 = serial_get_initiator_socket(p2, idx2);
+    auto* t1 = serial_get_target_socket(p1);
+    auto* t2 = serial_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid serial port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid serial port", p2->name());
@@ -389,10 +391,10 @@ void serial_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = serial_get_initiator_socket(p1, idx1);
+    auto* i2 = serial_get_initiator_socket(p2);
+    auto* t1 = serial_get_target_socket(p1, idx1);
+    auto* t2 = serial_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid serial port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid serial port", p2->name());
@@ -415,10 +417,10 @@ void serial_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = serial_get_initiator_socket(p1, idx1);
+    auto* i2 = serial_get_initiator_socket(p2, idx2);
+    auto* t1 = serial_get_target_socket(p1, idx1);
+    auto* t2 = serial_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid serial port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid serial port", p2->name());

--- a/src/vcml/protocols/spi.cpp
+++ b/src/vcml/protocols/spi.cpp
@@ -94,23 +94,23 @@ spi_target_stub::spi_target_stub(const char* nm):
     spi_in.bind(*this);
 }
 
-static spi_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static spi_base_initiator_socket* spi_get_initiator_socket(sc_object* port) {
     return dynamic_cast<spi_base_initiator_socket*>(port);
 }
 
-static spi_base_target_socket* get_target_socket(sc_object* port) {
+static spi_base_target_socket* spi_get_target_socket(sc_object* port) {
     return dynamic_cast<spi_base_target_socket*>(port);
 }
 
-static spi_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static spi_base_initiator_socket* spi_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<spi_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static spi_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static spi_base_target_socket* spi_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<spi_base_target_socket>(idx, true);
     return nullptr;
@@ -120,7 +120,7 @@ spi_base_initiator_socket& spi_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = spi_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -129,7 +129,7 @@ spi_base_initiator_socket& spi_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = spi_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -138,7 +138,7 @@ spi_base_target_socket& spi_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = spi_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -147,7 +147,7 @@ spi_base_target_socket& spi_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = spi_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -156,8 +156,8 @@ void spi_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = spi_get_initiator_socket(child);
+    auto* tgt = spi_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid spi socket", child->name());
@@ -172,13 +172,13 @@ void spi_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    spi_base_initiator_socket* isock = get_initiator_socket(child, idx);
+    spi_base_initiator_socket* isock = spi_get_initiator_socket(child, idx);
     if (isock) {
         isock->stub();
         return;
     }
 
-    spi_base_target_socket* tsock = get_target_socket(child, idx);
+    spi_base_target_socket* tsock = spi_get_target_socket(child, idx);
     if (tsock) {
         tsock->stub();
         return;
@@ -195,10 +195,10 @@ void spi_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = spi_get_initiator_socket(p1);
+    auto* i2 = spi_get_initiator_socket(p2);
+    auto* t1 = spi_get_target_socket(p1);
+    auto* t2 = spi_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid spi port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid spi port", p2->name());
@@ -221,10 +221,10 @@ void spi_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = spi_get_initiator_socket(p1);
+    auto* i2 = spi_get_initiator_socket(p2, idx2);
+    auto* t1 = spi_get_target_socket(p1);
+    auto* t2 = spi_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid spi port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid spi port", p2->name());
@@ -247,10 +247,10 @@ void spi_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = spi_get_initiator_socket(p1, idx1);
+    auto* i2 = spi_get_initiator_socket(p2);
+    auto* t1 = spi_get_target_socket(p1, idx1);
+    auto* t2 = spi_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid spi port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid spi port", p2->name());
@@ -273,10 +273,10 @@ void spi_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = spi_get_initiator_socket(p1, idx1);
+    auto* i2 = spi_get_initiator_socket(p2, idx2);
+    auto* t1 = spi_get_target_socket(p1, idx1);
+    auto* t2 = spi_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid spi port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid spi port", p2->name());

--- a/src/vcml/protocols/usb_sockets.cpp
+++ b/src/vcml/protocols/usb_sockets.cpp
@@ -181,23 +181,23 @@ usb_target_stub::usb_target_stub(const char* nm):
     usb_in.bind(*this);
 }
 
-static usb_base_initiator_socket* get_initiator_socket(sc_object* port) {
+static usb_base_initiator_socket* usb_get_initiator_socket(sc_object* port) {
     return dynamic_cast<usb_base_initiator_socket*>(port);
 }
 
-static usb_base_target_socket* get_target_socket(sc_object* port) {
+static usb_base_target_socket* usb_get_target_socket(sc_object* port) {
     return dynamic_cast<usb_base_target_socket*>(port);
 }
 
-static usb_base_initiator_socket* get_initiator_socket(sc_object* array,
-                                                       size_t idx) {
+static usb_base_initiator_socket* usb_get_initiator_socket(sc_object* array,
+                                                           size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<usb_base_initiator_socket>(idx, true);
     return nullptr;
 }
 
-static usb_base_target_socket* get_target_socket(sc_object* array,
-                                                 size_t idx) {
+static usb_base_target_socket* usb_get_target_socket(sc_object* array,
+                                                     size_t idx) {
     if (auto* aif = dynamic_cast<socket_array_if*>(array))
         return aif->fetch_as<usb_base_target_socket>(idx, true);
     return nullptr;
@@ -207,7 +207,7 @@ usb_base_initiator_socket& usb_initiator(const sc_object& parent,
                                          const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child);
+    auto* sock = usb_get_initiator_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -216,7 +216,7 @@ usb_base_initiator_socket& usb_initiator(const sc_object& parent,
                                          const string& port, size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_initiator_socket(child, idx);
+    auto* sock = usb_get_initiator_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid initiator socket", child->name());
     return *sock;
 }
@@ -225,7 +225,7 @@ usb_base_target_socket& usb_target(const sc_object& parent,
                                    const string& port) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child);
+    auto* sock = usb_get_target_socket(child);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -234,7 +234,7 @@ usb_base_target_socket& usb_target(const sc_object& parent, const string& port,
                                    size_t idx) {
     sc_object* child = find_child(parent, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", parent.name(), port.c_str());
-    auto* sock = get_target_socket(child, idx);
+    auto* sock = usb_get_target_socket(child, idx);
     VCML_ERROR_ON(!sock, "%s is not a valid target socket", child->name());
     return *sock;
 }
@@ -243,8 +243,8 @@ void usb_stub(const sc_object& obj, const string& port) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child);
-    auto* tgt = get_target_socket(child);
+    auto* ini = usb_get_initiator_socket(child);
+    auto* tgt = usb_get_target_socket(child);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid usb socket", child->name());
@@ -259,8 +259,8 @@ void usb_stub(const sc_object& obj, const string& port, size_t idx) {
     sc_object* child = find_child(obj, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", obj.name(), port.c_str());
 
-    auto* ini = get_initiator_socket(child, idx);
-    auto* tgt = get_target_socket(child, idx);
+    auto* ini = usb_get_initiator_socket(child, idx);
+    auto* tgt = usb_get_target_socket(child, idx);
 
     if (!ini && !tgt)
         VCML_ERROR("%s is not a valid usb socket", child->name());
@@ -279,10 +279,10 @@ void usb_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = usb_get_initiator_socket(p1);
+    auto* i2 = usb_get_initiator_socket(p2);
+    auto* t1 = usb_get_target_socket(p1);
+    auto* t2 = usb_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid usb port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid usb port", p2->name());
@@ -305,10 +305,10 @@ void usb_bind(const sc_object& obj1, const string& port1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = usb_get_initiator_socket(p1);
+    auto* i2 = usb_get_initiator_socket(p2, idx2);
+    auto* t1 = usb_get_target_socket(p1);
+    auto* t2 = usb_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid usb port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid usb port", p2->name());
@@ -331,10 +331,10 @@ void usb_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2);
+    auto* i1 = usb_get_initiator_socket(p1, idx1);
+    auto* i2 = usb_get_initiator_socket(p2);
+    auto* t1 = usb_get_target_socket(p1, idx1);
+    auto* t2 = usb_get_target_socket(p2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid usb port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid usb port", p2->name());
@@ -357,10 +357,10 @@ void usb_bind(const sc_object& obj1, const string& port1, size_t idx1,
     VCML_ERROR_ON(!p1, "%s.%s does not exist", obj1.name(), port1.c_str());
     VCML_ERROR_ON(!p2, "%s.%s does not exist", obj2.name(), port2.c_str());
 
-    auto* i1 = get_initiator_socket(p1, idx1);
-    auto* i2 = get_initiator_socket(p2, idx2);
-    auto* t1 = get_target_socket(p1, idx1);
-    auto* t2 = get_target_socket(p2, idx2);
+    auto* i1 = usb_get_initiator_socket(p1, idx1);
+    auto* i2 = usb_get_initiator_socket(p2, idx2);
+    auto* t1 = usb_get_target_socket(p1, idx1);
+    auto* t2 = usb_get_target_socket(p2, idx2);
 
     VCML_ERROR_ON(!i1 && !t1, "%s is not a valid usb port", p1->name());
     VCML_ERROR_ON(!i2 && !t2, "%s is not a valid usb port", p2->name());


### PR DESCRIPTION
Rework VCML to enable unity building.

Introduce a new CMake option, `VCML_UNITY_BUILD`, that enables/disables unity building. By default it is off, and only enabled in the CI. Currently, there are some issues with MSVC, so windows flows will not use it.

Update the cmake & googletest submodules to raise the minimum CMake version and fix some issues with the version string.

Lastly, replace the soon-to-be-deprecated windows-2019 runner with windows-2025.

Please do a rebase merge, so that the commit history is preserved.