### PR TITLE
sc_async: block async thread on suspend

### DIFF
--- a/include/vcml/core/processor.h
+++ b/include/vcml/core/processor.h
@@ -39,6 +39,7 @@ class processor : public component, public debugging::target
 {
 private:
     double m_run_time;
+    bool m_async;
 
     std::mutex m_cycle_mtx;
     std::unordered_map<sc_process_b*, u64> m_cycle_count;

--- a/include/vcml/core/systemc.h
+++ b/include/vcml/core/systemc.h
@@ -386,6 +386,8 @@ void sc_async(function<void(void)> job, int affinity = -1);
 void sc_progress(const sc_time& delta);
 void sc_sync(function<void(void)> job);
 void sc_join_async();
+void sc_suspend_async(const sc_module* owner = nullptr);
+void sc_resume_async(const sc_module* owner = nullptr);
 
 bool sc_is_async();
 

--- a/src/vcml/debugging/gdbserver.cpp
+++ b/src/vcml/debugging/gdbserver.cpp
@@ -956,6 +956,9 @@ string gdbserver::handle_vcont(const string& cmd) {
         }
     }
 
+    for (auto gtgt : m_targets)
+        gtgt.tgt.set_running(false);
+
     update_status(GDB_STOPPED);
 
     if (sim_running() && !simulation_suspended()) {


### PR DESCRIPTION
When a suspender wants to suspend a processor that is in async mode, the async threads needs to be stopped before suspension. Otherwise, the processor might fetch its registers (update register properties) on suspend while the ISS is still running in the async thread. This leads to faulty behavior on resume if old register values are written back from properties to the ISS.

This PR adds the possibility to block async threads.
The `block_async` methods returns once the thread is blocked. The `unblock_asnyc` methods unblocks the async thread. Async threads can only be blocked during `sc_progress` and `sc_sync` calls.

This PR increases the complexity of the `async_worker`. Private methods are introduced (`async_blocked` and `async_blocked`) and the `progress` member is turned private to enusre the `progress` function is used to enable blocking. Because of the introduction of private members and functions, I changed the `async_worker` from a struct to a class.