### PR TITLE
processor: allow blocking when single cycle left

### DIFF
--- a/src/vcml/core/processor.cpp
+++ b/src/vcml/core/processor.cpp
@@ -189,8 +189,10 @@ bool processor::processor_thread_async() {
             }
 
             // do not execute a single cycle to avoid tb flushes
-            if (cycles_left == 1)
+            if (cycles_left == 1) {
+                sc_progress(SC_ZERO_TIME);
                 break;
+            }
 
             simulate_cycles(min(cycles_left, step_size));
             update_local_time(lt, current_process());


### PR DESCRIPTION
When in async mode and a single cycle is left in the quantum, `sc_progress` needs to be called to allow blocking of the async thread. Otherwise, the simulation is stuck.