### PR TITLE
gic: distribute SPI 1-N

### DIFF
--- a/src/vcml/models/arm/gic400.cpp
+++ b/src/vcml/models/arm/gic400.cpp
@@ -839,8 +839,9 @@ void gic400::cpuif::write_eoir(u32 val) {
     if (ctlr.bank(cpu) & eoi_mode_mask)
         return;
 
-    m_parent->set_irq_active(irq, false, bit(cpu));
-    m_parent->set_irq_signaled(irq, false, bit(cpu));
+    cpu_mask_t cpu_mask = m_parent->get_cpu_mask(cpu, irq);
+    m_parent->set_irq_active(irq, false, cpu_mask);
+    m_parent->set_irq_signaled(irq, false, cpu_mask);
     m_parent->update();
 }
 
@@ -1391,6 +1392,9 @@ gic400::gic400(const sc_module_name& nm):
     rst.bind(cpuif.rst);
     rst.bind(vifctrl.rst);
     rst.bind(vcpuif.rst);
+
+    for (size_t i = NPRV; i < NPRV + NSPI; i++)
+        m_irq_state[i].model = N_1;
 }
 
 gic400::~gic400() {


### PR DESCRIPTION
According the to [ARM's GICv2 spec](https://developer.arm.com/documentation/ihi0048/latest/), for SPIs, the 1-N model is used. This means they are handled by a single CPU core instead of all cores:

>3.1.1 Handling different interrupt types in a multiprocessor system
>A GIC supports peripheral interrupts and software-generated interrupts, see Interrupt types on page 1-18.
>In a multiprocessor implementation the GIC handles:
>• software generated interrupts (SGIs) using the GIC N-N model
>• peripheral (hardware) interrupts using the GIC 1-N model.

To follow the spec, the model of all SPIs is set to 1-N in the constructor of the GIC. When SGIs are EOIed, the active and signaled state of the SPI has to be changed for all cores.