### PR TITLE
vspserver: finish elaboration before listening

### DIFF
--- a/src/vcml/debugging/vspserver.cpp
+++ b/src/vcml/debugging/vspserver.cpp
@@ -766,11 +766,11 @@ vspserver::~vspserver() {
 }
 
 void vspserver::start() {
-    run_async();
-
     // Finish elaboration first before processing commands
     sc_start(SC_ZERO_TIME);
     suspend();
+
+    run_async();
 
     log_info("vspserver waiting on port %hu", port());
 


### PR DESCRIPTION
When the VSP server is launched before the elaboration phase is over, it can happen that a VSP client can suspend the simulation during the elaboration phase. When the client then continues the simulation, the simulation just finishes the elaboration phase because it is automatically suspended afterward.
To prevent this issue, the thread that runs the server is started after the elaboration phase has been finished and the simulation has been suspended.