### PR TITLE
feat(rspserver): Use errnos as error codes

### DIFF
--- a/include/vcml/debugging/rspserver.h
+++ b/include/vcml/debugging/rspserver.h
@@ -77,12 +77,6 @@ public:
 
     void register_handler(const char* command, handler handler);
     void unregister_handler(const char* command);
-
-    static const char* const ERR_COMMAND;  // malformed command
-    static const char* const ERR_PARAM;    // parameter has invalid value
-    static const char* const ERR_INTERNAL; // internal error
-    static const char* const ERR_UNKNOWN;  // unknown error
-    static const char* const ERR_PROTOCOL; // protocol error
 };
 
 template <typename HOST>
@@ -94,6 +88,8 @@ void rspserver::register_handler(const char* command,
         return (host->*handler)(args);
     });
 }
+
+string rsp_error(int eno);
 
 } // namespace debugging
 } // namespace vcml

--- a/src/vcml/debugging/rspserver.cpp
+++ b/src/vcml/debugging/rspserver.cpp
@@ -275,7 +275,7 @@ void rspserver::unregister_handler(const char* cmd) {
 }
 
 string rsp_error(int eno) {
-    return mkstr("E%02d", eno);
+    return mkstr("E%02x", eno);
 }
 
 } // namespace debugging

--- a/src/vcml/debugging/rspserver.cpp
+++ b/src/vcml/debugging/rspserver.cpp
@@ -246,10 +246,10 @@ string rspserver::handle_command(const string& command) {
         return ""; // empty response means command not supported
     } catch (report& rep) {
         log.error(rep);
-        return ERR_INTERNAL;
+        return rsp_error(EINVAL);
     } catch (std::exception& ex) {
         log.error(ex);
-        return ERR_INTERNAL;
+        return rsp_error(EINVAL);
     }
 }
 
@@ -274,11 +274,9 @@ void rspserver::unregister_handler(const char* cmd) {
     m_handlers.erase(cmd);
 }
 
-const char* const rspserver::ERR_COMMAND = "E01";
-const char* const rspserver::ERR_PARAM = "E02";
-const char* const rspserver::ERR_INTERNAL = "E03";
-const char* const rspserver::ERR_UNKNOWN = "E04";
-const char* const rspserver::ERR_PROTOCOL = "E05";
+string rsp_error(int eno) {
+    return mkstr("E%02d", eno);
+}
 
 } // namespace debugging
 } // namespace vcml


### PR DESCRIPTION
Also, return an error when a mem read fails.

Fixes: 457e7aa8880b4188f14171896001c4c47db25106 ("Be more lenient when gdb cannot read memory")