### PR TITLE
peripheral: remove current cpuid and replace with current_sbi

### DIFF
--- a/include/vcml/core/peripheral.h
+++ b/include/vcml/core/peripheral.h
@@ -28,8 +28,6 @@ class reg_base;
 class peripheral : public component
 {
 private:
-    int m_current_cpu;
-
     unordered_map<address_space, reg_bank*> m_registers;
 
     bool cmd_mmap(const vector<string>& args, ostream& os);
@@ -61,8 +59,7 @@ public:
     template <typename T>
     T from_host_endian(T val) const;
 
-    int current_cpu() const { return m_current_cpu; }
-    void set_current_cpu(int cpu) { m_current_cpu = cpu; }
+    int current_cpu() const { return current_sideband().cpuid; }
 
     void aligned_accesses_only(bool only = true);
     void aligned_accesses_only(address_space as, bool only = true);

--- a/include/vcml/protocols/tlm_host.h
+++ b/include/vcml/protocols/tlm_host.h
@@ -67,6 +67,10 @@ protected:
     address_space current_transaction_address_space(
         sc_process_b* proc = current_process()) const;
 
+    void set_current_transaction(tlm_generic_payload& tx, const tlm_sbi& sbi,
+                                 address_space as,
+                                 sc_process_b* proc = current_process());
+    void clear_current_transaction(sc_process_b* proc = current_process());
     void set_current_response_status(tlm_response_status status,
                                      sc_process_b* proc = current_process());
 

--- a/src/vcml/core/peripheral.cpp
+++ b/src/vcml/core/peripheral.cpp
@@ -88,7 +88,6 @@ unsigned int peripheral::forward_to_regs(tlm_generic_payload& tx,
 peripheral::peripheral(const sc_module_name& nm, endianess default_endian,
                        unsigned int rlatency, unsigned int wlatency):
     component(nm),
-    m_current_cpu(SBI_NONE.cpuid),
     m_registers(),
     endian("endian", default_endian),
     read_latency("read_latency", rlatency),
@@ -211,6 +210,12 @@ unsigned int peripheral::transport(tlm_generic_payload& tx,
     unsigned int be_length = tx.get_byte_enable_length();
     unsigned int be_index = 0;
     unsigned int nbytes = 0;
+    bool clear_tx = false;
+
+    if (!in_transaction()) {
+        set_current_transaction(tx, info, as);
+        clear_tx = true;
+    }
 
     VCML_ERROR_ON(ptr == nullptr, "transaction data pointer cannot be null");
     VCML_ERROR_ON(length == 0, "transaction data length cannot be zero");
@@ -259,6 +264,9 @@ unsigned int peripheral::transport(tlm_generic_payload& tx,
     tx.set_byte_enable_ptr(be_ptr);
     tx.set_byte_enable_length(be_length);
 
+    if (clear_tx)
+        clear_current_transaction();
+
     // check for quantum overshoot
     if (!info.is_debug && needs_sync())
         sync();
@@ -283,9 +291,7 @@ unsigned int peripheral::receive(tlm_generic_payload& tx, const tlm_sbi& info,
         return 0;
     }
 
-    set_current_cpu(info.cpuid);
     bytes = forward_to_regs(tx, info, as);
-    set_current_cpu(SBI_NONE.cpuid);
     if (success(tx) || failed(tx)) // stop if at least one reg took the access
         return bytes;
 

--- a/src/vcml/protocols/tlm_host.cpp
+++ b/src/vcml/protocols/tlm_host.cpp
@@ -13,14 +13,26 @@
 
 namespace vcml {
 
+void tlm_host::set_current_transaction(tlm_generic_payload& tx,
+                                       const tlm_sbi& sbi, address_space as,
+                                       sc_process_b* proc) {
+    auto& current = lookup_process_data(proc);
+    current.tx = &tx;
+    current.sbi = &sbi;
+    current.as = as;
+}
+
+void tlm_host::clear_current_transaction(sc_process_b* proc) {
+    auto& current = lookup_process_data(proc);
+    current.tx = nullptr;
+    current.sbi = nullptr;
+    current.as = VCML_AS_DEFAULT;
+}
+
 unsigned int tlm_host::do_transport(tlm_target_socket& socket,
                                     tlm_generic_payload& tx,
                                     const tlm_sbi& info) {
-    auto& current = lookup_process_data();
-
-    current.tx = &tx;
-    current.sbi = &info;
-    current.as = socket.as;
+    set_current_transaction(tx, info, socket.as);
 
     if (tx.get_response_status() != TLM_INCOMPLETE_RESPONSE)
         VCML_ERROR("invalid in-bound transaction response status");
@@ -30,9 +42,7 @@ unsigned int tlm_host::do_transport(tlm_target_socket& socket,
     if (tx.get_response_status() == TLM_INCOMPLETE_RESPONSE)
         VCML_ERROR("invalid out-bound transaction response status");
 
-    current.tx = nullptr;
-    current.sbi = nullptr;
-    current.as = VCML_AS_DEFAULT;
+    clear_current_transaction();
 
     return n;
 }


### PR DESCRIPTION
Remove `peripheral::m_current_cpu` and replace with `tlm_host::current_sbi().cpuid`. This fixes the issue that current cpu id is not available during `peripheral::read` and `peripheral::write`.

The changes in `peripheral::transport` are only needed because some tests in `test/unit/registers.cpp` (banking) bypass the setting of current SBI info, so we need to set it again here. Ideally we don't want that, but that would require rewriting the tests.