### PR TITLE
fix(can): remove errant frame deref with CANXL_RRS

### DIFF
--- a/src/vcml/models/can/backend_socket.cpp
+++ b/src/vcml/models/can/backend_socket.cpp
@@ -144,7 +144,7 @@ backend_socket::backend_socket(bridge* br, const string& ifname):
 
 #ifdef CANXL_RRS
             if (xl_frame.flags & CANXL_RRS)
-                frame->flags |= CAN_XL_RRS;
+                frame.flags |= CAN_XL_RRS;
 #endif
 
 #ifdef CANXL_VCID_OFFSET


### PR DESCRIPTION
Fixes a build failure.

It might be worth adding builds with more recent kernels to CI in order to try to catch this kind of thing earlier?