### PR TITLE
fix: on_write_mask for array registers setting all registers

### DIFF
--- a/include/vcml/core/register.h
+++ b/include/vcml/core/register.h
@@ -481,8 +481,8 @@ void reg<DATA, N, STRIDE>::on_write(void (HOST::*wr)(DATA, size_t, bool),
 
 template <typename DATA, size_t N, size_t STRIDE>
 void reg<DATA, N, STRIDE>::on_write_mask(DATA mask) {
-    on_write([this, mask](DATA val) -> void {
-        *this = (*this & ~mask) | (val & mask);
+    on_write([this, mask](DATA val, size_t i) -> void {
+        current_bank(i) = (current_bank(i) & ~mask) | (val & mask);
     });
 }
 

--- a/include/vcml/core/register.h
+++ b/include/vcml/core/register.h
@@ -482,14 +482,17 @@ void reg<DATA, N, STRIDE>::on_write(void (HOST::*wr)(DATA, size_t, bool),
 template <typename DATA, size_t N, size_t STRIDE>
 void reg<DATA, N, STRIDE>::on_write_mask(DATA mask) {
     on_write([this, mask](DATA val, size_t i) -> void {
-        current_bank(i) = (current_bank(i) & ~mask) | (val & mask);
+        size_t idx = N > 1 ? i : 0;
+        current_bank(idx) = (current_bank(idx) & ~mask) | (val & mask);
     });
 }
 
 template <typename DATA, size_t N, size_t STRIDE>
 void reg<DATA, N, STRIDE>::on_write_mask(const array<DATA, N>& mask) {
     on_write([this, mask](DATA val, size_t i) -> void {
-        current_bank(i) = (current_bank(i) & ~mask[i]) | (val & mask[i]);
+        size_t idx = N > 1 ? i : 0;
+        current_bank(idx) = (current_bank(idx) & ~mask[idx]) |
+                            (val & mask[idx]);
     });
 }
 

--- a/test/unit/register.cpp
+++ b/test/unit/register.cpp
@@ -667,6 +667,29 @@ TEST(registers, write_mask_scalar_array) {
     EXPECT_EQ(mock.scalar_masked_reg[1], 0x00ffu);
 }
 
+class mock_peripheral_mask_tagged : public peripheral
+{
+public:
+    reg<u32> tagged_reg;
+
+    mock_peripheral_mask_tagged(const sc_module_name& nm):
+        peripheral(nm), tagged_reg("tagged_reg", 0x0, 0xdeadbeef) {
+        tagged_reg.allow_read_write();
+        tagged_reg.tag = 42;
+        tagged_reg.on_write_mask(0x0000ffffu);
+        clk.stub(100 * MHz);
+        rst.stub();
+    }
+};
+
+TEST(registers, write_mask_nonzero_tag) {
+    mock_peripheral_mask_tagged mock("write_mask_nonzero_tag");
+
+    u32 val = 0xffffffffu;
+    mock.tagged_reg.do_write(0, 0, sizeof(u32), &val, false);
+    EXPECT_EQ(mock.tagged_reg, 0xdeadffffu);
+}
+
 class test_peripheral_sockets : public peripheral
 {
 public:

--- a/test/unit/register.cpp
+++ b/test/unit/register.cpp
@@ -591,15 +591,19 @@ class mock_peripheral_mask : public peripheral
 public:
     reg<u32> test_reg;
     reg<u32, 4> array_reg;
+    reg<u32, 2> scalar_masked_reg;
 
     mock_peripheral_mask(const sc_module_name& nm):
         peripheral(nm),
         test_reg("test_reg", 0x0),
-        array_reg("array_reg", 0x10, { 1, 2, 4, 8 }) {
+        array_reg("array_reg", 0x10, { 1, 2, 4, 8 }),
+        scalar_masked_reg("scalar_masked_reg", 0x20, { 0xaa00u, 0xbbu }) {
         test_reg.allow_read_write();
         array_reg.allow_read_write();
+        scalar_masked_reg.allow_read_write();
         test_reg.on_write_mask(0x10101010);
         array_reg.on_write_mask({ { 1, 2, 4, 8 } });
+        scalar_masked_reg.on_write_mask(0xffu);
         clk.stub(100 * MHz);
         rst.stub();
     }
@@ -647,6 +651,20 @@ TEST(registers, masking) {
     tx_setup(tx, TLM_WRITE_COMMAND, 0x1c, &data, sizeof(data));
     EXPECT_EQ(mock.transport(tx, SBI_NONE, VCML_AS_DEFAULT), 4);
     EXPECT_EQ(mock.array_reg[3], 8);
+}
+
+TEST(registers, write_mask_scalar_array) {
+    mock_peripheral_mask mock("write_mask_scalar_array");
+
+    u32 val = 0xffu;
+
+    mock.scalar_masked_reg.do_write(0, 0, sizeof(u32), &val, false);
+    EXPECT_EQ(mock.scalar_masked_reg[0], 0xaaffu);
+    EXPECT_EQ(mock.scalar_masked_reg[1], 0x00bbu);
+
+    mock.scalar_masked_reg.do_write(1, 0, sizeof(u32), &val, false);
+    EXPECT_EQ(mock.scalar_masked_reg[0], 0xaaffu);
+    EXPECT_EQ(mock.scalar_masked_reg[1], 0x00ffu);
 }
 
 class test_peripheral_sockets : public peripheral


### PR DESCRIPTION
`on_write_mask` for scalar masks was accidentally setting all registers on write callback.
The problem was that `*this = ...` is overloaded to write in all registers (see `operator=`), whereas `operator DATA()` only returns the current bank, That effectively led to one register writing its value into all registers.
See:
```c++
template <typename DATA, size_t N, size_t STRIDE>
reg<DATA, N, STRIDE>::operator DATA() const {
    return current_bank();
}

template <typename DATA, size_t N, size_t STRIDE>
inline reg<DATA, N, STRIDE>& reg<DATA, N, STRIDE>::operator=(
    const reg<DATA, N, STRIDE>& r) {
    for (size_t i = 0; i < N; i++)
        current_bank(i) = r.current_bank(i);
    return *this;
}
```

For array masks this was already properly implemented:
```c++
template <typename DATA, size_t N, size_t STRIDE>
void reg<DATA, N, STRIDE>::on_write_mask(const array<DATA, N>& mask) {
    on_write([this, mask](DATA val, size_t i) -> void {
        current_bank(i) = (current_bank(i) & ~mask[i]) | (val & mask[i]);
    });
}
```

The only remaining question is: What is the semantic of a single mask being passed to a register array?
My expectation would be a mask applied to all registers in the array.

If you like, we can also map this to `on_write_mask` with an array of size 1.