### PR TITLE
fix: has_readfn and has_writefn were using value-initialization syntax x instead of type

### DIFF
--- a/include/vcml/core/register.h
+++ b/include/vcml/core/register.h
@@ -369,12 +369,12 @@ private:
 
 template <typename DATA, size_t N, size_t STRIDE>
 bool reg<DATA, N, STRIDE>::has_readfn() const {
-    return !std::holds_alternative<std::monostate()>(m_readfn);
+    return !std::holds_alternative<std::monostate>(m_readfn);
 }
 
 template <typename DATA, size_t N, size_t STRIDE>
 bool reg<DATA, N, STRIDE>::has_writefn() const {
-    return !std::holds_alternative<std::monostate()>(m_writefn);
+    return !std::holds_alternative<std::monostate>(m_writefn);
 }
 
 template <typename DATA, size_t N, size_t STRIDE>

--- a/test/unit/register.cpp
+++ b/test/unit/register.cpp
@@ -846,6 +846,21 @@ TEST(registers, debug_read_write_periph) {
     mock.test_reg_tag.do_write(0, 0, 4, &data, true);
 }
 
+TEST(registers, has_fn) {
+    mock_peripheral mock;
+
+    EXPECT_FALSE(mock.test_reg_a.has_readfn());
+    EXPECT_FALSE(mock.test_reg_a.has_writefn());
+
+    mock.test_reg_a.on_read([]() -> u32 { return 0; });
+    EXPECT_TRUE(mock.test_reg_a.has_readfn());
+    EXPECT_FALSE(mock.test_reg_a.has_writefn());
+
+    mock.test_reg_a.on_write([](u32) {});
+    EXPECT_TRUE(mock.test_reg_a.has_readfn());
+    EXPECT_TRUE(mock.test_reg_a.has_writefn());
+}
+
 class mock_peripheral_strided : public peripheral
 {
 public:


### PR DESCRIPTION
`std::holds_alternative` expects a type, not an object of type `std::monostate`.
This never blew up, because `has_writefn` and `has_readfn` were never used anywhere.