### PR TITLE
fix: reg array with init list needs to call reg class

### DIFF
--- a/include/vcml/core/register.h
+++ b/include/vcml/core/register.h
@@ -612,7 +612,7 @@ reg<DATA, N, STRIDE>::reg(const tlm_target_socket& socket, const string& name,
 template <typename DATA, size_t N, size_t STRIDE>
 reg<DATA, N, STRIDE>::reg(const tlm_target_socket& socket, const string& name,
                           u64 addr, std::initializer_list<DATA> data):
-    reg_base(socket.as, name, addr, data) {
+    reg<DATA, N, STRIDE>(socket.as, name, addr, data) {
 }
 
 template <typename DATA, size_t N, size_t STRIDE>

--- a/test/unit/register.cpp
+++ b/test/unit/register.cpp
@@ -657,6 +657,7 @@ public:
 
     reg<u32> test_reg_a;
     reg<u32> test_reg_b;
+    reg<u32, 2> test_reg_array;
 
     test_peripheral_sockets(
         const sc_module_name& nm = sc_gen_unique_name("peripheral_sockets")):
@@ -664,7 +665,8 @@ public:
         in_a("in_a", VCML_AS_TEST1),
         in_b("in_b", VCML_AS_TEST2),
         test_reg_a(in_a, "test_reg_a", 0x0, 0xffffffff),
-        test_reg_b(in_b, "test_reg_b", 0x0, 0xffffffff) {
+        test_reg_b(in_b, "test_reg_b", 0x0, 0xffffffff),
+        test_reg_array(in_a, "test_reg_array", 0x4, { 0x11u, 0x22u }) {
         test_reg_b.allow_read_write();
         test_reg_b.allow_read_write();
         clk.stub(100 * MHz);
@@ -706,6 +708,26 @@ TEST(registers, socket_address_spaces) {
     EXPECT_EQ(mock.test_transport(tx, VCML_AS_TEST2), 4);
     EXPECT_EQ(mock.test_reg_a, 0xffffffffu);
     EXPECT_EQ(mock.test_reg_b, 0x44332211u);
+    EXPECT_TRUE(tx.is_response_ok());
+    mock.reset();
+    tx_reset(tx);
+
+    EXPECT_EQ(mock.test_reg_array[0], 0x11u);
+    EXPECT_EQ(mock.test_reg_array[1], 0x22u);
+    tx.set_address(0x04);
+    EXPECT_EQ(mock.test_transport(tx, VCML_AS_TEST1), 4);
+    EXPECT_EQ(mock.test_reg_array[0], 0x44332211u);
+    EXPECT_EQ(mock.test_reg_array[1], 0x22u);
+    EXPECT_TRUE(tx.is_response_ok());
+    mock.reset();
+    tx_reset(tx);
+
+    EXPECT_EQ(mock.test_reg_array[0], 0x11u);
+    EXPECT_EQ(mock.test_reg_array[1], 0x22u);
+    tx.set_address(0x08);
+    EXPECT_EQ(mock.test_transport(tx, VCML_AS_TEST1), 4);
+    EXPECT_EQ(mock.test_reg_array[0], 0x11u);
+    EXPECT_EQ(mock.test_reg_array[1], 0x44332211u);
     EXPECT_TRUE(tx.is_response_ok());
     mock.reset();
     tx_reset(tx);


### PR DESCRIPTION
The wrong constructor was called, leading to a compile error.
Probably the first time someone using a register array with an initializer list and a target socket.
The same function with a scalar initializer was doing it correctly.
See:

```c++
template <typename DATA, size_t N, size_t STRIDE>
reg<DATA, N, STRIDE>::reg(address_space a, const string& nm, u64 addr,
                          std::initializer_list<DATA> init):
    reg_base(a, nm, addr, sizeof(DATA), N, STRIDE),
    property<DATA, N>(nm.c_str(), init),
    m_banked(false),
    m_init(),
    m_banks(),
    m_readfn(),
    m_writefn() {
    for (size_t i = 0; i < N; i++)
        m_init[i] = property<DATA, N>::get(i);
}

template <typename DATA, size_t N, size_t STRIDE>
reg<DATA, N, STRIDE>::reg(const tlm_target_socket& socket, const string& name,
                          u64 addr, DATA data):
    reg<DATA, N, STRIDE>(socket.as, name, addr, data) {
}

template <typename DATA, size_t N, size_t STRIDE>
reg<DATA, N, STRIDE>::reg(const tlm_target_socket& socket, const string& name,
                          u64 addr, std::initializer_list<DATA> data):
    /* Don't call reg_base here */ {
}

```