### PR TITLE
test: increasing sc_time coverage

### DIFF
--- a/include/vcml/core/systemc.h
+++ b/include/vcml/core/systemc.h
@@ -412,6 +412,8 @@ void on_end_of_simulation(function<void(void)> callback);
 void on_each_delta_cycle(function<void(void)> callback);
 void on_each_time_step(function<void(void)> callback);
 
+void clear_timed_callbacks();
+
 class async_timer
 {
 public:

--- a/src/vcml/core/systemc.cpp
+++ b/src/vcml/core/systemc.cpp
@@ -577,6 +577,13 @@ void on_each_time_step(function<void(void)> callback) {
     helper.tsteps.push_back(std::move(callback));
 }
 
+void clear_timed_callbacks() {
+    helper_module& helper = helper_module::instance();
+    lock_guard<mutex> guard(helper.mtx);
+    helper.deltas.clear();
+    helper.tsteps.clear();
+}
+
 async_timer::async_timer(function<void(async_timer&)> cb):
     m_triggers(0), m_timeout(), m_event(nullptr), m_cb(std::move(cb)) {
 }

--- a/test/unit/sysc.cpp
+++ b/test/unit/sysc.cpp
@@ -11,20 +11,65 @@
 #include "testing.h"
 
 TEST(systemc, time) {
+    sc_core::sc_set_time_resolution(1.0, SC_FS);
+
+#if SYSTEMC_VERSION >= SYSTEMC_VERSION_3_0_0
+    EXPECT_FALSE(time_unit_is_resolvable(SC_YS));
+    EXPECT_EQ(time_to_ys(sc_time(1.0, SC_FS)), 1'000'000'000ull);
+    EXPECT_EQ(time_to_ys(sc_time(1.0, SC_PS)), 1'000'000'000'000ull);
+    EXPECT_EQ(time_to_ys(sc_time(1.0, SC_NS)), 1'000'000'000'000'000ull);
+    EXPECT_EQ(time_to_ys(sc_time(1.0, SC_US)), 1'000'000'000'000'000'000ull);
+
+    EXPECT_FALSE(time_unit_is_resolvable(SC_ZS));
+    EXPECT_EQ(time_to_zs(sc_time(1.0, SC_FS)), 1'000'000ull);
+    EXPECT_EQ(time_to_zs(sc_time(1.0, SC_PS)), 1'000'000'000ull);
+    EXPECT_EQ(time_to_zs(sc_time(1.0, SC_NS)), 1'000'000'000'000ull);
+    EXPECT_EQ(time_to_zs(sc_time(1.0, SC_US)), 1'000'000'000'000'000ull);
+
+    EXPECT_FALSE(time_unit_is_resolvable(SC_AS));
+    EXPECT_EQ(time_to_as(sc_time(1.0, SC_FS)), 1000ull);
+    EXPECT_EQ(time_to_as(sc_time(1.0, SC_PS)), 1'000'000ull);
+    EXPECT_EQ(time_to_as(sc_time(1.0, SC_NS)), 1'000'000'000ull);
+    EXPECT_EQ(time_to_as(sc_time(1.0, SC_US)), 1'000'000'000'000ull);
+    EXPECT_EQ(time_to_as(sc_time(1.0, SC_MS)), 1'000'000'000'000'000ull);
+#endif
+
+    EXPECT_TRUE(time_unit_is_resolvable(SC_FS));
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_FS)), 1ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.9, SC_FS)), 2ull);
+    EXPECT_EQ(time_to_fs(sc_time(2.0, SC_FS)), 2ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_PS)), 1000ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_NS)), 1'000'000ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_US)), 1'000'000'000ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_MS)), 1'000'000'000'000ull);
+    EXPECT_EQ(time_to_fs(sc_time(1.0, SC_SEC)), 1'000'000'000'000'000ull);
+
+    EXPECT_TRUE(time_unit_is_resolvable(SC_PS));
+    EXPECT_EQ(time_to_ps(sc_time(1.0, SC_PS)), 1ull);
+    EXPECT_EQ(time_to_ps(sc_time(1.9, SC_PS)), 1ull);
+    EXPECT_EQ(time_to_ps(sc_time(2.0, SC_PS)), 2ull);
+    EXPECT_EQ(time_to_ps(sc_time(1.0, SC_NS)), 1000ull);
+    EXPECT_EQ(time_to_ps(sc_time(1.0, SC_US)), 1'000'000ull);
+    EXPECT_EQ(time_to_ps(sc_time(1.0, SC_MS)), 1'000'000'000ull);
+    EXPECT_EQ(time_to_ps(sc_time(1.0, SC_SEC)), 1'000'000'000'000ull);
+
+    EXPECT_TRUE(time_unit_is_resolvable(SC_NS));
     EXPECT_EQ(time_to_ns(sc_time(1.0, SC_NS)), 1ull);
     EXPECT_EQ(time_to_ns(sc_time(1.9, SC_NS)), 1ull);
     EXPECT_EQ(time_to_ns(sc_time(2.0, SC_NS)), 2ull);
     EXPECT_EQ(time_to_ns(sc_time(1.0, SC_US)), 1000ull);
-    EXPECT_EQ(time_to_ns(sc_time(1.0, SC_MS)), 1000ull * 1000ull);
-    EXPECT_EQ(time_to_ns(sc_time(1.0, SC_SEC)), 1000ull * 1000ull * 1000ull);
+    EXPECT_EQ(time_to_ns(sc_time(1.0, SC_MS)), 1'000'000ull);
+    EXPECT_EQ(time_to_ns(sc_time(1.0, SC_SEC)), 1'000'000'000ull);
 
+    EXPECT_TRUE(time_unit_is_resolvable(SC_US));
     EXPECT_EQ(time_to_us(sc_time(1.0, SC_NS)), 0ull);
     EXPECT_EQ(time_to_us(sc_time(1.0, SC_US)), 1ull);
     EXPECT_EQ(time_to_us(sc_time(1.9, SC_US)), 1ull);
     EXPECT_EQ(time_to_us(sc_time(2.0, SC_US)), 2ull);
     EXPECT_EQ(time_to_us(sc_time(1.0, SC_MS)), 1000ull);
-    EXPECT_EQ(time_to_us(sc_time(1.0, SC_SEC)), 1000ull * 1000ull);
+    EXPECT_EQ(time_to_us(sc_time(1.0, SC_SEC)), 1'000'000ull);
 
+    EXPECT_TRUE(time_unit_is_resolvable(SC_MS));
     EXPECT_EQ(time_to_ms(sc_time(1.0, SC_NS)), 0ull);
     EXPECT_EQ(time_to_ms(sc_time(1.0, SC_US)), 0ull);
     EXPECT_EQ(time_to_ms(sc_time(1.0, SC_MS)), 1ull);
@@ -80,4 +125,21 @@ TEST(systemc, callback) {
 
     sc_core::sc_start(10, SC_SEC);
     EXPECT_TRUE(update_called);
+}
+
+TEST(systemc, time_stamp) {
+    sc_report_handler::set_actions(SC_ID_NO_SC_START_ACTIVITY_, SC_DO_NOTHING);
+
+    bool checked = false;
+    on_each_time_step([&checked]() {
+        sc_time now = sc_time_stamp();
+        EXPECT_EQ(time_stamp_ns(), time_to_ns(now));
+        EXPECT_EQ(time_stamp_us(), time_to_us(now));
+        EXPECT_EQ(time_stamp_ms(), time_to_ms(now));
+        EXPECT_EQ(time_stamp_sec(), time_to_sec(now));
+        checked = true;
+    });
+
+    sc_core::sc_start(1, SC_SEC);
+    EXPECT_TRUE(checked);
 }

--- a/test/unit/sysc.cpp
+++ b/test/unit/sysc.cpp
@@ -125,6 +125,7 @@ TEST(systemc, callback) {
 
     sc_core::sc_start(10, SC_SEC);
     EXPECT_TRUE(update_called);
+    clear_timed_callbacks();
 }
 
 TEST(systemc, time_stamp) {
@@ -142,4 +143,5 @@ TEST(systemc, time_stamp) {
 
     sc_core::sc_start(1, SC_SEC);
     EXPECT_TRUE(checked);
+    clear_timed_callbacks();
 }


### PR DESCRIPTION
Currently, the tests of systemc.h and systemc.cpp live in two separate files: sysc.cpp and sc_time.cpp.
Probably a historical artifact, but some time-related tests live in sysc.cpp.
__QUESTION: If you are OK with it, can I move my and the already existing sc_time tests to sc_time.cpp?__

Moreover, I introduced `clear_timed_callbacks()` which clears all delta-cycle and time step callbacks.
This is needed because some tests use lambdas with reference capturing of local variables, leading to stack corruptions.