### PR TITLE
fix: tlm_memory oob read/write and broken move constructor

### DIFF
--- a/src/vcml/protocols/tlm_memory_posix.cpp
+++ b/src/vcml/protocols/tlm_memory_posix.cpp
@@ -74,7 +74,7 @@ tlm_memory::tlm_memory(tlm_memory&& other) noexcept:
     m_base(other.m_base),
     m_size(other.m_size),
     m_discard(other.m_discard),
-    m_shared(other.m_shared) {
+    m_shared(std::move(other.m_shared)) {
     other.m_handle = nullptr;
     other.m_base = nullptr;
     other.m_size = 0;

--- a/src/vcml/protocols/tlm_memory_posix.cpp
+++ b/src/vcml/protocols/tlm_memory_posix.cpp
@@ -78,6 +78,7 @@ tlm_memory::tlm_memory(tlm_memory&& other) noexcept:
     other.m_handle = nullptr;
     other.m_base = nullptr;
     other.m_size = 0;
+    other.m_shared = "";
     other.free();
 }
 

--- a/src/vcml/protocols/tlm_memory_posix.cpp
+++ b/src/vcml/protocols/tlm_memory_posix.cpp
@@ -73,7 +73,8 @@ tlm_memory::tlm_memory(tlm_memory&& other) noexcept:
     m_handle(other.m_handle),
     m_base(other.m_base),
     m_size(other.m_size),
-    m_discard(other.m_discard) {
+    m_discard(other.m_discard),
+    m_shared(other.m_shared) {
     other.m_handle = nullptr;
     other.m_base = nullptr;
     other.m_size = 0;
@@ -104,6 +105,8 @@ void tlm_memory::init(const string& shared, size_t size, alignment al) {
         flags |= MAP_PRIVATE | MAP_ANON;
 
     m_base = mmap(0, m_size, perms, flags, fd, 0);
+    if (fd >= 0)
+        close(fd);
     VCML_ERROR_ON(m_base == MAP_FAILED, "mmap failed: %s", strerror(errno));
     u8* ptr = (u8*)(((u64)m_base + extra) & ~extra);
     VCML_ERROR_ON(!is_aligned(ptr, al), "memory alignment failed");
@@ -141,7 +144,7 @@ tlm_response_status tlm_memory::fill(u8 data, bool debug) {
 
 tlm_response_status tlm_memory::read(const range& addr, void* dest,
                                      bool debug) {
-    if (addr.end >= m_size)
+    if (addr.end >= size())
         return TLM_ADDRESS_ERROR_RESPONSE;
 
     if (!debug && !is_read_allowed())
@@ -153,7 +156,7 @@ tlm_response_status tlm_memory::read(const range& addr, void* dest,
 
 tlm_response_status tlm_memory::write(const range& addr, const void* src,
                                       bool debug) {
-    if (addr.end >= m_size)
+    if (addr.end >= size())
         return TLM_ADDRESS_ERROR_RESPONSE;
 
     if (!debug) {

--- a/src/vcml/protocols/tlm_memory_win32.cpp
+++ b/src/vcml/protocols/tlm_memory_win32.cpp
@@ -74,7 +74,7 @@ tlm_memory::tlm_memory(tlm_memory&& other) noexcept:
     m_base(other.m_base),
     m_size(other.m_size),
     m_discard(other.m_discard),
-    m_shared(other.m_shared) {
+    m_shared(std::move(other.m_shared)) {
     other.m_handle = INVALID_HANDLE_VALUE;
     other.m_base = nullptr;
     other.m_size = 0;

--- a/src/vcml/protocols/tlm_memory_win32.cpp
+++ b/src/vcml/protocols/tlm_memory_win32.cpp
@@ -73,10 +73,12 @@ tlm_memory::tlm_memory(tlm_memory&& other) noexcept:
     m_handle(other.m_handle),
     m_base(other.m_base),
     m_size(other.m_size),
-    m_discard(other.m_discard) {
+    m_discard(other.m_discard),
+    m_shared(other.m_shared) {
     other.m_handle = INVALID_HANDLE_VALUE;
     other.m_base = nullptr;
     other.m_size = 0;
+    other.m_shared = "";
     other.free();
 }
 
@@ -138,7 +140,7 @@ tlm_response_status tlm_memory::fill(u8 data, bool debug) {
 
 tlm_response_status tlm_memory::read(const range& addr, void* dest,
                                      bool debug) {
-    if (addr.end >= m_size)
+    if (addr.end >= size())
         return TLM_ADDRESS_ERROR_RESPONSE;
 
     if (!debug && !is_read_allowed())
@@ -150,7 +152,7 @@ tlm_response_status tlm_memory::read(const range& addr, void* dest,
 
 tlm_response_status tlm_memory::write(const range& addr, const void* src,
                                       bool debug) {
-    if (addr.end >= m_size)
+    if (addr.end >= size())
         return TLM_ADDRESS_ERROR_RESPONSE;
 
     if (!debug) {

--- a/test/unit/memory.cpp
+++ b/test/unit/memory.cpp
@@ -85,6 +85,24 @@ TEST(memory, readwrite) {
     EXPECT_EQ(mem[0], data) << "debug write has no effect";
 }
 
+TEST(memory, transport) {
+    tlm_memory mem(1);
+    u8 data = 0x42;
+    tlm_generic_payload tx;
+    tlm_sbi sbi;
+
+    tx_setup(tx, TLM_WRITE_COMMAND, 0, &data, sizeof(data));
+    mem.transport(tx, sbi);
+    EXPECT_EQ(tx.get_response_status(), tlm::TLM_OK_RESPONSE);
+    EXPECT_EQ(mem[0], 0x42);
+
+    mem[0] = 0x23;
+    tx_setup(tx, TLM_READ_COMMAND, 0, &data, sizeof(data));
+    mem.transport(tx, sbi);
+    EXPECT_EQ(tx.get_response_status(), tlm::TLM_OK_RESPONSE);
+    EXPECT_EQ(data, 0x23);
+}
+
 TEST(memory, move) {
     const size_t size = 4 * KiB;
 

--- a/test/unit/memory.cpp
+++ b/test/unit/memory.cpp
@@ -130,8 +130,8 @@ TEST(memory, move_constructor) {
 
     tlm_memory moved = std::move(orig);
 
-    EXPECT_FALSE(orig.is_shared());
-    EXPECT_EQ(orig.size(), 0);
+    EXPECT_FALSE(orig.is_shared()); // NOLINT
+    EXPECT_EQ(orig.size(), 0);      // NOLINT
 
     EXPECT_TRUE(moved.is_shared());
     EXPECT_EQ(moved.size(), size);
@@ -154,4 +154,21 @@ TEST(memory, aligned_oob_rejected) {
         << "read into alignment must be rejected";
     EXPECT_AE(mem.write(range(size, size), buf.data(), false))
         << "write into alignment must berejected";
+}
+
+TEST(memory, fill) {
+    tlm_memory mem(4 * KiB, VCML_ALIGN_4K);
+
+    ASSERT_OK(mem.fill(0xaa, false));
+    ASSERT_EQ(mem[0], 0xaa);
+
+    // TODO: What should be the behavior here?
+    mem.discard_writes(true);
+    ASSERT_OK(mem.fill(0xcc, true));
+    ASSERT_EQ(mem[0], 0xcc);
+
+    // TODO: What should be the behavior here?
+    // mem.discard_writes(true);
+    // ASSERT_OK(mem.fill(0xbb, false));
+    // ASSERT_EQ(mem[0], 0xaa);
 }

--- a/test/unit/memory.cpp
+++ b/test/unit/memory.cpp
@@ -118,6 +118,29 @@ TEST(memory, move) {
     EXPECT_EQ(move.data(), data) << "memory pointer not moved";
 }
 
+TEST(memory, move_shared) {
+    const size_t size = 4 * KiB;
+    const string name = "/vcml-test-move-shared";
+
+    tlm_memory orig(name, size);
+    orig[0] = 0xab;
+    EXPECT_TRUE(orig.is_shared());
+
+    tlm_memory moved = std::move(orig);
+
+    EXPECT_FALSE(orig.is_shared()); // NOLINT
+    EXPECT_EQ(orig.size(), 0);      // NOLINT
+    EXPECT_EQ(orig.data(), nullptr);
+
+    EXPECT_TRUE(moved.is_shared());
+    EXPECT_EQ(moved.size(), size);
+    EXPECT_STREQ(moved.shared_name(), name.c_str());
+
+    u8 data;
+    EXPECT_OK(moved.read(0, data));
+    EXPECT_EQ(data, 0xab);
+}
+
 TEST(memory, sharing) {
     const size_t size = 16 * KiB;
     const string name = "/vcml-test-shared";
@@ -136,28 +159,6 @@ TEST(memory, sharing_wrong_size) {
     tlm_memory a(name, size);
     EXPECT_DEATH({ tlm_memory b(name, size * 2); }, "unexpected size");
     EXPECT_DEATH({ tlm_memory b(name, size / 2); }, "unexpected size");
-}
-
-TEST(memory, move_constructor) {
-    const size_t size = 4 * KiB;
-    const string name = "/vcml-test-move-shared";
-
-    tlm_memory orig(name, size);
-    orig[0] = 0xab;
-    EXPECT_TRUE(orig.is_shared());
-
-    tlm_memory moved = std::move(orig);
-
-    EXPECT_FALSE(orig.is_shared()); // NOLINT
-    EXPECT_EQ(orig.size(), 0);      // NOLINT
-
-    EXPECT_TRUE(moved.is_shared());
-    EXPECT_EQ(moved.size(), size);
-    EXPECT_STREQ(moved.shared_name(), name.c_str());
-
-    u8 data;
-    EXPECT_OK(moved.read(0, data));
-    EXPECT_EQ(data, 0xab);
 }
 
 TEST(memory, aligned_oob_rejected) {

--- a/test/unit/memory.cpp
+++ b/test/unit/memory.cpp
@@ -180,13 +180,9 @@ TEST(memory, fill) {
     ASSERT_OK(mem.fill(0xaa, false));
     ASSERT_EQ(mem[0], 0xaa);
 
-    // TODO: What should be the behavior here?
     mem.discard_writes(true);
-    ASSERT_OK(mem.fill(0xcc, true));
+    ASSERT_OK(mem.fill(0xbb, true));
+    ASSERT_EQ(mem[0], 0xbb);
+    ASSERT_OK(mem.fill(0xcc, false));
     ASSERT_EQ(mem[0], 0xcc);
-
-    // TODO: What should be the behavior here?
-    // mem.discard_writes(true);
-    // ASSERT_OK(mem.fill(0xbb, false));
-    // ASSERT_EQ(mem[0], 0xaa);
 }

--- a/test/unit/memory.cpp
+++ b/test/unit/memory.cpp
@@ -60,6 +60,13 @@ TEST(memory, readwrite) {
     tlm_memory mem(1);
 
     u8 data = 0x42;
+
+    mem.discard_writes(true);
+    mem[0] = 0;
+    EXPECT_OK(mem.write(0, data)) << "discard_writes mem rejected write";
+    EXPECT_EQ(mem[0], 0) << "discard_writes mem stored the write";
+
+    mem.discard_writes(false);
     EXPECT_OK(mem.write(range(0, 0), &data, false)) << "write failed";
     EXPECT_EQ(mem[0], data) << "data not stored";
 
@@ -111,4 +118,40 @@ TEST(memory, sharing_wrong_size) {
     tlm_memory a(name, size);
     EXPECT_DEATH({ tlm_memory b(name, size * 2); }, "unexpected size");
     EXPECT_DEATH({ tlm_memory b(name, size / 2); }, "unexpected size");
+}
+
+TEST(memory, move_constructor) {
+    const size_t size = 4 * KiB;
+    const string name = "/vcml-test-move-shared";
+
+    tlm_memory orig(name, size);
+    orig[0] = 0xab;
+    EXPECT_TRUE(orig.is_shared());
+
+    tlm_memory moved = std::move(orig);
+
+    EXPECT_FALSE(orig.is_shared());
+    EXPECT_EQ(orig.size(), 0);
+
+    EXPECT_TRUE(moved.is_shared());
+    EXPECT_EQ(moved.size(), size);
+    EXPECT_STREQ(moved.shared_name(), name.c_str());
+
+    u8 data;
+    EXPECT_OK(moved.read(0, data));
+    EXPECT_EQ(data, 0xab);
+}
+
+TEST(memory, aligned_oob_rejected) {
+    const size_t size = 4 * KiB;
+    tlm_memory mem(size, VCML_ALIGN_8M); // force extra size by aligment
+    vector<u8> buf(size, 0xff);
+
+    EXPECT_OK(mem.read(range(0, size - 1), buf.data(), false))
+        << "accesses within [0, size-1] must succeed";
+
+    EXPECT_AE(mem.read(range(size, size), buf.data(), false))
+        << "read into alignment must be rejected";
+    EXPECT_AE(mem.write(range(size, size), buf.data(), false))
+        << "write into alignment must berejected";
 }


### PR DESCRIPTION
- Move constructor: Didn't move the shared attribute. 
__QUESTION: I guess the semantic is to keep the share alive, right?__
- The file descriptor is now closed after mmaping it.
- Some out-of-bonds writes/read were accepted if the memory's alignment was greater than the host alignment.
This happened because of the following comparison:
```c++
    if (addr.end >= m_size)
        return TLM_ADDRESS_ERROR_RESPONSE;
```
 `m_size` can be greater than the actual size of the memory since it includes padding:
 ```c++
    u64 extra = (al > host_page_alignment()) ? (1ull << al) - 1 : 0;
    m_size = size + extra;
```
The fix: instead of `m_size`, use `size()`.
- __QUESTION: What should be the behavior of `fill` when using `discard_writes(true)`?__
Currently, the behavior between the same function with different arguments differs:
```c++
inline void tlm_memory::fill(u8 val) {
    memset(data(), val, size());
}

tlm_response_status tlm_memory::fill(u8 data, bool debug) {
    if (!is_write_allowed() && !debug)
        return m_discard ? TLM_OK_RESPONSE : TLM_COMMAND_ERROR_RESPONSE;

    fill(data);
    return TLM_OK_RESPONSE;
}
``` 

Furthermore, `is_write_allowed` does not cover `m_discard`! That means, a memory with `m_discard=true` can be filled..