### PR TITLE
feat: adding avr gdbarch

### DIFF
--- a/include/vcml/debugging/gdbarch.h
+++ b/include/vcml/debugging/gdbarch.h
@@ -69,6 +69,7 @@ struct gdbarch {
     static const gdbarch AARCH64;
     static const gdbarch ARM;
     static const gdbarch ARM_M;
+    static const gdbarch AVR;
     static const gdbarch OR1K;
     static const gdbarch RISCV;
 };

--- a/src/vcml/debugging/gdbarch.cpp
+++ b/src/vcml/debugging/gdbarch.cpp
@@ -213,7 +213,7 @@ const gdbarch gdbarch::AVR = gdbarch(
           { "r0",  "r1",  "r2",  "r3",  "r4",  "r5",   "r6",  "r7",  "r8",
             "r9",  "r10", "r11", "r12", "r13", "r14",  "r15", "r16", "r17",
             "r18", "r19", "r20", "r21", "r22", "r23",  "r24", "r25", "r26",
-            "r27", "r28", "r29", "r30", "r31", "sreg", "sp",  "pc" } },
+            "r27", "r28", "r29", "r30", "r31", "sreg", "sp",  "pc2" } },
     });
 
 const gdbarch gdbarch::OR1K = gdbarch(

--- a/src/vcml/debugging/gdbarch.cpp
+++ b/src/vcml/debugging/gdbarch.cpp
@@ -209,10 +209,11 @@ const gdbarch gdbarch::ARM_M = gdbarch(
 const gdbarch gdbarch::AVR = gdbarch(
     "avr", "avr", "none",
     {
-        { "", { "r0",  "r1",  "r2",  "r3",  "r4",  "r5",   "r6",  "r7",  "r8",
-                "r9",  "r10", "r11", "r12", "r13", "r14",  "r15", "r16", "r17",
-                "r18", "r19", "r20", "r21", "r22", "r23",  "r24", "r25", "r26",
-                "r27", "r28", "r29", "r30", "r31", "sreg", "sp",  "pc" } },
+        { "org.gnu.gdb.avr.core",
+          { "r0",  "r1",  "r2",  "r3",  "r4",  "r5",   "r6",  "r7",  "r8",
+            "r9",  "r10", "r11", "r12", "r13", "r14",  "r15", "r16", "r17",
+            "r18", "r19", "r20", "r21", "r22", "r23",  "r24", "r25", "r26",
+            "r27", "r28", "r29", "r30", "r31", "sreg", "sp",  "pc" } },
     });
 
 const gdbarch gdbarch::OR1K = gdbarch(

--- a/src/vcml/debugging/gdbarch.cpp
+++ b/src/vcml/debugging/gdbarch.cpp
@@ -206,6 +206,15 @@ const gdbarch gdbarch::ARM_M = gdbarch(
             "r11", "r12", "sp", "lr", "pc", "xpsr" } },
     });
 
+const gdbarch gdbarch::AVR = gdbarch(
+    "avr", "avr", "none",
+    {
+        { "", { "r0",  "r1",  "r2",  "r3",  "r4",  "r5",   "r6",  "r7",  "r8",
+                "r9",  "r10", "r11", "r12", "r13", "r14",  "r15", "r16", "r17",
+                "r18", "r19", "r20", "r21", "r22", "r23",  "r24", "r25", "r26",
+                "r27", "r28", "r29", "r30", "r31", "sreg", "sp",  "pc" } },
+    });
+
 const gdbarch gdbarch::OR1K = gdbarch(
     "or1k", "or1k", "none",
     {


### PR DESCRIPTION
If you compare the VCML implemenation against the [GDB side](https://gnu.googlesource.com/binutils-gdb/+/refs/heads/master/gdb/avr-tdep.c#206), you may notice a missing "pc" register in the VCML implementation.
Note that this a pseudo register, which is internally computed by GDB based on the "pc2" register.
GDB only fetches pc*2 from the VP and then calculates pc by shifting right.
The GDB code is somewhat confusing because it sometimes uses "pc2" and "pc", and other times it is `AVR_PC_REGNUM` and  `AVR_PSEUDO_PC_REGNUM`.

