### PR TITLE
fix: pixelformat for 3-byte formats

### DIFF
--- a/src/vcml/ui/video.cpp
+++ b/src/vcml/ui/video.cpp
@@ -131,9 +131,9 @@ color_channel pixelformat_r(pixelformat fmt) {
     case FORMAT_B8G8R8X8:
         return { 8, 8 };
     case FORMAT_R8G8B8:
-        return { 16, 8 };
-    case FORMAT_B8G8R8:
         return { 0, 8 };
+    case FORMAT_B8G8R8:
+        return { 16, 8 };
     case FORMAT_R5G6B5:
         return { 11, 5 };
     case FORMAT_B5G6R5:
@@ -197,9 +197,9 @@ color_channel pixelformat_b(pixelformat fmt) {
     case FORMAT_B8G8R8X8:
         return { 24, 8 };
     case FORMAT_R8G8B8:
-        return { 0, 8 };
-    case FORMAT_B8G8R8:
         return { 16, 8 };
+    case FORMAT_B8G8R8:
+        return { 0, 8 };
     case FORMAT_R5G6B5:
         return { 0, 5 };
     case FORMAT_B5G6R5:


### PR DESCRIPTION
3-byte color formats are byte-addressed. whereas 2-byte and 4-byte formats are integer-packed and depend on the host machine endianess.
Hence, you would get the following memory layouts (little endian assumed):

R8G8B8:
0: R
1: G
2: B

A8R8G8B8:
0: B
1: G
2: R
3: A

This patch fixes the offsets of the 3-byte pixelformat.

On top of that, there are some deeper rooting issues with 3-byte pixelformats and endianness, but let's discuss this separately.

