### PR TITLE
fix(ui): adding missing 3-byte format for read_pixel

### DIFF
--- a/include/vcml/ui/display.h
+++ b/include/vcml/ui/display.h
@@ -70,6 +70,16 @@ inline u32 display::read_pixel(u32 x, u32 y) const {
         return mwr::read_once<u8>(ptr);
     case 2:
         return mwr::read_once<u16>(ptr);
+    case 3: {
+        u32 val = mwr::read_once<u32>(ptr);
+        if (host_endian() == ENDIAN_BIG) {
+            val >>= 8;
+        } else {
+            val = (mwr::extract(val, 0, 8) << 16) |
+                  (mwr::extract(val, 8, 8) << 8) | mwr::extract(val, 16, 8);
+        }
+        return val;
+    }
     case 4:
         return mwr::read_once<u32>(ptr);
     default:

--- a/include/vcml/ui/display.h
+++ b/include/vcml/ui/display.h
@@ -70,16 +70,8 @@ inline u32 display::read_pixel(u32 x, u32 y) const {
         return mwr::read_once<u8>(ptr);
     case 2:
         return mwr::read_once<u16>(ptr);
-    case 3: {
-        u32 val = mwr::read_once<u32>(ptr);
-        if (host_endian() == ENDIAN_BIG) {
-            val >>= 8;
-        } else {
-            val = (mwr::extract(val, 0, 8) << 16) |
-                  (mwr::extract(val, 8, 8) << 8) | mwr::extract(val, 16, 8);
-        }
-        return val;
-    }
+    case 3:
+        return mwr::extract(mwr::read_once<u32>(ptr), 0, 24);
     case 4:
         return mwr::read_once<u32>(ptr);
     default:


### PR DESCRIPTION
Adding the missing 3-byte format for reading pixels.
Note that all 3-byte types are array-packed and need endianness correction.
Meaning they always reside in memory as:
```
R G B  
0 1 2
```

In general, the cleaner way would be to get a format's packaging, and do the corresponding processing.
If we ever move to SDL3, there would be a corresponding function for that:  [SDL_GetPixelFormatDetails
](https://wiki.libsdl.org/SDL3/SDL_GetPixelFormatDetails)
