### PR TITLE
feat: adding i2c bus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(vcml STATIC
     ${src}/vcml/models/can/bridge.cpp
     ${src}/vcml/models/can/bus.cpp
     ${src}/vcml/models/can/m_can.cpp
+    ${src}/vcml/models/i2c/bus.cpp
     ${src}/vcml/models/i2c/lm75.cpp
     ${src}/vcml/models/i2c/ads1015.cpp
     ${src}/vcml/models/i2c/oci2c.cpp

--- a/include/vcml.h
+++ b/include/vcml.h
@@ -126,6 +126,7 @@
 #include "vcml/models/can/bus.h"
 #include "vcml/models/can/m_can.h"
 
+#include "vcml/models/i2c/bus.h"
 #include "vcml/models/i2c/lm75.h"
 #include "vcml/models/i2c/ads1015.h"
 #include "vcml/models/i2c/oci2c.h"

--- a/include/vcml/models/i2c/bus.h
+++ b/include/vcml/models/i2c/bus.h
@@ -46,6 +46,12 @@ public:
 };
 
 } // namespace i2c
+
+void i2c_bind(i2c::bus& bus, sc_object& socket, string port);
+void i2c_bind(i2c::bus& bus, sc_object& socket, string portarray, size_t idx);
+void i2c_bind(i2c::bus& bus, const string& socket);
+void i2c_bind(i2c::bus& bus, const string& socket, size_t idx);
+
 } // namespace vcml
 
 #endif

--- a/include/vcml/models/i2c/bus.h
+++ b/include/vcml/models/i2c/bus.h
@@ -47,8 +47,9 @@ public:
 
 } // namespace i2c
 
-void i2c_bind(i2c::bus& bus, sc_object& socket, string port);
-void i2c_bind(i2c::bus& bus, sc_object& socket, string portarray, size_t idx);
+void i2c_bind(i2c::bus& bus, sc_object& socket, const string& port);
+void i2c_bind(i2c::bus& bus, sc_object& socket, const string& portarray,
+              size_t idx);
 void i2c_bind(i2c::bus& bus, const string& socket);
 void i2c_bind(i2c::bus& bus, const string& socket, size_t idx);
 

--- a/include/vcml/models/i2c/bus.h
+++ b/include/vcml/models/i2c/bus.h
@@ -33,7 +33,7 @@ public:
     virtual ~bus() = default;
     VCML_KIND(i2c::bus);
 
-    i2c_target_socket i2c_in;
+    i2c_target_array<> i2c_in;
     i2c_initiator_array<> i2c_out;
 
     virtual void reset() override;
@@ -41,9 +41,7 @@ public:
     virtual void i2c_transport(i2c_target_socket& socket,
                                i2c_payload& tx) override;
 
-    unsigned int next_free() const;
-
-    void bind(i2c_initiator_socket& initiator);
+    unsigned int bind(i2c_initiator_socket& initiator);
     unsigned int bind(i2c_target_socket& target);
 };
 

--- a/include/vcml/models/i2c/bus.h
+++ b/include/vcml/models/i2c/bus.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2026 MachineWare GmbH                                        *
+ * All Rights Reserved                                                        *
+ *                                                                            *
+ * This work is licensed under the terms described in the LICENSE file found  *
+ * in the root directory of this source tree.                                 *
+ *                                                                            *
+ ******************************************************************************/
+
+#ifndef VCML_I2C_BUS_H
+#define VCML_I2C_BUS_H
+
+#include "vcml/core/types.h"
+#include "vcml/core/systemc.h"
+#include "vcml/core/component.h"
+#include "vcml/core/model.h"
+
+#include "vcml/logging/logger.h"
+#include "vcml/properties/property.h"
+
+#include "vcml/protocols/i2c.h"
+
+namespace vcml {
+namespace i2c {
+
+class bus : public component, public i2c_host
+{
+public:
+    bus() = delete;
+    bus(const bus&) = delete;
+    bus(const sc_module_name& nm);
+    virtual ~bus() = default;
+    VCML_KIND(i2c::bus);
+
+    i2c_target_socket i2c_in;
+    i2c_initiator_array<> i2c_out;
+
+    virtual void reset() override;
+
+    virtual void i2c_transport(i2c_target_socket& socket,
+                               i2c_payload& tx) override;
+
+    unsigned int next_free() const;
+
+    void bind(i2c_initiator_socket& initiator);
+    unsigned int bind(i2c_target_socket& target);
+};
+
+} // namespace i2c
+} // namespace vcml
+
+#endif

--- a/src/vcml/models/i2c/bus.cpp
+++ b/src/vcml/models/i2c/bus.cpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2026 MachineWare GmbH                                        *
+ * All Rights Reserved                                                        *
+ *                                                                            *
+ * This work is licensed under the terms described in the LICENSE file found  *
+ * in the root directory of this source tree.                                 *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "vcml/models/i2c/bus.h"
+
+namespace vcml {
+namespace i2c {
+
+bus::bus(const sc_module_name& nm):
+    component(nm), i2c_host(), i2c_in("i2c_in"), i2c_out("i2c_out") {
+}
+
+void bus::reset() {
+    component::reset();
+}
+
+void bus::i2c_transport(i2c_target_socket&, i2c_payload& tx) {
+    for (auto& port : i2c_out)
+        port.second->transport(tx);
+}
+
+unsigned int bus::next_free() const {
+    unsigned int idx = 0;
+    while (i2c_out.exists(idx))
+        VCML_ERROR_ON(++idx == 0, "no free ports");
+    return idx;
+}
+
+void bus::bind(i2c_initiator_socket& initiator) {
+    i2c_in.bind(initiator);
+}
+
+unsigned int bus::bind(i2c_target_socket& target) {
+    unsigned int port = next_free();
+    i2c_out[port].bind(target);
+    return port;
+}
+
+VCML_EXPORT_MODEL(vcml::i2c::bus, name, args) {
+    return new bus(name);
+}
+
+} // namespace i2c
+} // namespace vcml

--- a/src/vcml/models/i2c/bus.cpp
+++ b/src/vcml/models/i2c/bus.cpp
@@ -26,19 +26,14 @@ void bus::i2c_transport(i2c_target_socket&, i2c_payload& tx) {
         port.second->transport(tx);
 }
 
-unsigned int bus::next_free() const {
-    unsigned int idx = 0;
-    while (i2c_out.exists(idx))
-        VCML_ERROR_ON(++idx == 0, "no free ports");
-    return idx;
-}
-
-void bus::bind(i2c_initiator_socket& initiator) {
-    i2c_in.bind(initiator);
+unsigned int bus::bind(i2c_initiator_socket& initiator) {
+    unsigned int port = i2c_in.next_index();
+    i2c_in[port].bind(initiator);
+    return port;
 }
 
 unsigned int bus::bind(i2c_target_socket& target) {
-    unsigned int port = next_free();
+    unsigned int port = i2c_out.next_index();
     i2c_out[port].bind(target);
     return port;
 }

--- a/src/vcml/models/i2c/bus.cpp
+++ b/src/vcml/models/i2c/bus.cpp
@@ -58,13 +58,14 @@ static void i2c_bind_socket(i2c::bus& bus, sc_object& socket) {
     VCML_ERROR("%s is not a valid i2c socket", socket.name());
 }
 
-void i2c_bind(i2c::bus& bus, sc_object& socket, string port) {
+void i2c_bind(i2c::bus& bus, sc_object& socket, const string& port) {
     sc_object* child = find_child(socket, port);
     VCML_ERROR_ON(!child, "%s.%s does not exist", socket.name(), port.c_str());
     i2c_bind_socket(bus, *child);
 }
 
-void i2c_bind(i2c::bus& bus, sc_object& socket, string portarray, size_t idx) {
+void i2c_bind(i2c::bus& bus, sc_object& socket, const string& portarray,
+              size_t idx) {
     sc_object* child = find_child(socket, portarray);
     VCML_ERROR_ON(!child, "%s.%s does not exist", socket.name(),
                   portarray.c_str());

--- a/src/vcml/models/i2c/bus.cpp
+++ b/src/vcml/models/i2c/bus.cpp
@@ -43,4 +43,44 @@ VCML_EXPORT_MODEL(vcml::i2c::bus, name, args) {
 }
 
 } // namespace i2c
+
+static void i2c_bind_socket(i2c::bus& bus, sc_object& socket) {
+    if (auto* initiator = dynamic_cast<i2c_initiator_socket*>(&socket)) {
+        bus.bind(*initiator);
+        return;
+    }
+
+    if (auto* target = dynamic_cast<i2c_target_socket*>(&socket)) {
+        bus.bind(*target);
+        return;
+    }
+
+    VCML_ERROR("%s is not a valid i2c socket", socket.name());
+}
+
+void i2c_bind(i2c::bus& bus, sc_object& socket, string port) {
+    sc_object* child = find_child(socket, port);
+    VCML_ERROR_ON(!child, "%s.%s does not exist", socket.name(), port.c_str());
+    i2c_bind_socket(bus, *child);
+}
+
+void i2c_bind(i2c::bus& bus, sc_object& socket, string portarray, size_t idx) {
+    sc_object* child = find_child(socket, portarray);
+    VCML_ERROR_ON(!child, "%s.%s does not exist", socket.name(),
+                  portarray.c_str());
+
+    auto* array = dynamic_cast<socket_array_if*>(child);
+    VCML_ERROR_ON(!array, "%s is not a valid i2c socket array", child->name());
+
+    i2c_bind_socket(bus, *array->fetch(idx, true));
+}
+
+void i2c_bind(i2c::bus& bus, const string& socket) {
+    i2c_bind_socket(bus, find_socket(socket));
+}
+
+void i2c_bind(i2c::bus& bus, const string& socket, size_t idx) {
+    i2c_bind_socket(bus, find_socket(socket, idx));
+}
+
 } // namespace vcml

--- a/test/unit/i2c.cpp
+++ b/test/unit/i2c.cpp
@@ -66,7 +66,8 @@ public:
     i2c_target_array<> i2c_array_in;
 
     i2c::bus bus;
-    i2c_initiator_socket i2c_bus_master;
+    i2c_initiator_socket i2c_bus_master1;
+    i2c_initiator_socket i2c_bus_master2;
     i2c_target_array<> i2c_bus_slaves;
 
     i2c_bench(const sc_module_name& nm):
@@ -79,7 +80,8 @@ public:
         i2c_array_out("i2c_array_out"),
         i2c_array_in("i2c_array_in"),
         bus("bus"),
-        i2c_bus_master("i2c_bus_master"),
+        i2c_bus_master1("i2c_bus_master1"),
+        i2c_bus_master2("i2c_bus_master2"),
         i2c_bus_slaves("i2c_bus_slaves") {
         i2c_set_address(*this, "i2c_in", 42);
         EXPECT_EQ(i2c_in.address, 42);
@@ -113,7 +115,10 @@ public:
         clk_bind(*this, "clk", bus, "clk");
         gpio_bind(*this, "rst", bus, "rst");
 
-        bus.bind(i2c_bus_master);
+        // wire up two masters sharing the same bus
+        EXPECT_EQ(bus.bind(i2c_bus_master1), 0u);
+        EXPECT_EQ(bus.bind(i2c_bus_master2), 1u);
+
         EXPECT_EQ(bus.bind(i2c_bus_slaves[10]), 0u);
         EXPECT_EQ(bus.bind(i2c_bus_slaves[20]), 1u);
         EXPECT_EQ(bus.bind(i2c_bus_slaves[30]), 2u);
@@ -122,6 +127,8 @@ public:
         i2c_set_address(*this, "i2c_bus_slaves", 20, 20);
         i2c_set_address(*this, "i2c_bus_slaves", 30, 30);
 
+        EXPECT_TRUE(find_object("i2c.bus.i2c_in[0]"));
+        EXPECT_TRUE(find_object("i2c.bus.i2c_in[1]"));
         EXPECT_TRUE(find_object("i2c.bus.i2c_out[0]"));
         EXPECT_TRUE(find_object("i2c.bus.i2c_out[1]"));
         EXPECT_TRUE(find_object("i2c.bus.i2c_out[2]"));
@@ -180,23 +187,40 @@ public:
     }
 
     void test_bus() {
+        // master1 talks to the slave at address 20
         EXPECT_CALL(*this, i2c_start(i2c_match_address(20), TLM_WRITE_COMMAND))
             .Times(1)
             .WillOnce(Return(I2C_ACK));
-        EXPECT_ACK(i2c_bus_master.start(20, TLM_WRITE_COMMAND));
+        EXPECT_ACK(i2c_bus_master1.start(20, TLM_WRITE_COMMAND));
 
         u8 data = 0x55;
         EXPECT_CALL(*this, i2c_write(i2c_match_address(20), data))
             .Times(1)
             .WillOnce(Return(I2C_ACK));
-        EXPECT_ACK(i2c_bus_master.transport(data));
+        EXPECT_ACK(i2c_bus_master1.transport(data));
 
         EXPECT_CALL(*this, i2c_stop(i2c_match_address(20)))
             .Times(1)
             .WillOnce(Return(I2C_ACK));
-        EXPECT_ACK(i2c_bus_master.stop());
+        EXPECT_ACK(i2c_bus_master1.stop());
 
-        EXPECT_NACK(i2c_bus_master.start(99, TLM_WRITE_COMMAND));
+        // the same bus is reachable from a second master
+        EXPECT_CALL(*this, i2c_start(i2c_match_address(30), TLM_WRITE_COMMAND))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master2.start(30, TLM_WRITE_COMMAND));
+
+        EXPECT_CALL(*this, i2c_write(i2c_match_address(30), data))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master2.transport(data));
+
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(30)))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master2.stop());
+
+        EXPECT_NACK(i2c_bus_master1.start(99, TLM_WRITE_COMMAND));
     }
 };
 

--- a/test/unit/i2c.cpp
+++ b/test/unit/i2c.cpp
@@ -65,6 +65,10 @@ public:
     i2c_initiator_array<> i2c_array_out;
     i2c_target_array<> i2c_array_in;
 
+    i2c::bus bus;
+    i2c_initiator_socket i2c_bus_master;
+    i2c_target_array<> i2c_bus_slaves;
+
     i2c_bench(const sc_module_name& nm):
         test_base(nm),
         i2c_host(),
@@ -73,7 +77,10 @@ public:
         i2c_in_h("i2c_in_h"),
         i2c_in("i2c_in"),
         i2c_array_out("i2c_array_out"),
-        i2c_array_in("i2c_array_in") {
+        i2c_array_in("i2c_array_in"),
+        bus("bus"),
+        i2c_bus_master("i2c_bus_master"),
+        i2c_bus_slaves("i2c_bus_slaves") {
         i2c_set_address(*this, "i2c_in", 42);
         EXPECT_EQ(i2c_in.address, 42);
 
@@ -102,6 +109,25 @@ public:
         // did the stubs get created?
         EXPECT_TRUE(find_object("i2c.i2c_array_out[5]_stub"));
         EXPECT_TRUE(find_object("i2c.i2c_array_in[6]_stub"));
+
+        clk_bind(*this, "clk", bus, "clk");
+        gpio_bind(*this, "rst", bus, "rst");
+
+        bus.bind(i2c_bus_master);
+        EXPECT_EQ(bus.bind(i2c_bus_slaves[10]), 0u);
+        EXPECT_EQ(bus.bind(i2c_bus_slaves[20]), 1u);
+        EXPECT_EQ(bus.bind(i2c_bus_slaves[30]), 2u);
+
+        i2c_set_address(*this, "i2c_bus_slaves", 10, 10);
+        i2c_set_address(*this, "i2c_bus_slaves", 20, 20);
+        i2c_set_address(*this, "i2c_bus_slaves", 30, 30);
+
+        EXPECT_TRUE(find_object("i2c.bus.i2c_out[0]"));
+        EXPECT_TRUE(find_object("i2c.bus.i2c_out[1]"));
+        EXPECT_TRUE(find_object("i2c.bus.i2c_out[2]"));
+
+        add_test("protocol", &i2c_bench::test_protocol);
+        add_test("bus", &i2c_bench::test_bus);
     }
 
     MOCK_METHOD(i2c_response, i2c_start,
@@ -110,7 +136,7 @@ public:
     MOCK_METHOD(i2c_response, i2c_read, (const i2c_target_socket&, u8&));
     MOCK_METHOD(i2c_response, i2c_write, (const i2c_target_socket&, u8));
 
-    virtual void run_test() override {
+    void test_protocol() {
         // non-start commands must be ignored
         EXPECT_CALL(*this, i2c_read(_, _)).Times(0);
         EXPECT_CALL(*this, i2c_write(_, _)).Times(0);
@@ -151,6 +177,26 @@ public:
         EXPECT_ACK(i2c_out.stop());
         EXPECT_CALL(*this, i2c_write(_, data)).Times(0);
         EXPECT_NACK(i2c_out.transport(data));
+    }
+
+    void test_bus() {
+        EXPECT_CALL(*this, i2c_start(i2c_match_address(20), TLM_WRITE_COMMAND))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master.start(20, TLM_WRITE_COMMAND));
+
+        u8 data = 0x55;
+        EXPECT_CALL(*this, i2c_write(i2c_match_address(20), data))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master.transport(data));
+
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(20)))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_bus_master.stop());
+
+        EXPECT_NACK(i2c_bus_master.start(99, TLM_WRITE_COMMAND));
     }
 };
 


### PR DESCRIPTION
Implementation mainly inspired by the SPI bus with a few modernizations (default/deleted constructors, next_index instead of custom member functions).

Address matching is performed by simply forwarding the transaction to all recipients on the bus. The I2C protocol automatically rejects it if an address does not match. Maybe not the most efficient method, but definitely the simplest.