### PR TITLE
fix: i2c wrongly used address spaces instead of addresses

### DIFF
--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -53,7 +53,7 @@ ostream& operator<<(ostream& os, const i2c_payload& tx) {
 
 void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
     if (!stl_contains(m_state, socket.address.get()))
-        m_state[socket.as] = TLM_IGNORE_COMMAND;
+        m_state[socket.address.get()] = TLM_IGNORE_COMMAND;
 
     tlm_command& state = m_state[socket.address];
     if (state == TLM_IGNORE_COMMAND && tx.cmd != I2C_START)

--- a/test/unit/i2c.cpp
+++ b/test/unit/i2c.cpp
@@ -111,6 +111,15 @@ public:
     MOCK_METHOD(i2c_response, i2c_write, (const i2c_target_socket&, u8));
 
     virtual void run_test() override {
+        // non-start commands must be ignored
+        EXPECT_CALL(*this, i2c_read(_, _)).Times(0);
+        EXPECT_CALL(*this, i2c_write(_, _)).Times(0);
+        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
+
+        u8 unsolicited = 0xab;
+        EXPECT_NACK(i2c_out.transport(unsolicited));
+        EXPECT_NACK(i2c_out.stop());
+
         // test starting a read transfer
         EXPECT_CALL(*this, i2c_start(i2c_match_address(42), TLM_READ_COMMAND))
             .Times(1)


### PR DESCRIPTION
Code was wrongly using a socket's address space to access `m_state` and initialize its state.
That could potentially lead to read commands (the default value) being accepted without a preceding start command.