### PR TITLE
fix: i2c_read non-existent state + update_config not setting os bit

### DIFF
--- a/src/vcml/models/i2c/ads1015.cpp
+++ b/src/vcml/models/i2c/ads1015.cpp
@@ -247,6 +247,7 @@ void ads1015::update_config() {
     if (config & ADS1015_OS) {
         config &= ~ADS1015_OS;
         sample_data();
+        config |= ADS1015_OS;
     } else if (!polling && ads1015_is_continuous(config)) {
         sample_data();
     }
@@ -412,9 +413,6 @@ i2c_response ads1015::i2c_stop(const i2c_target_socket& socket) {
 i2c_response ads1015::i2c_read(const i2c_target_socket& socket, u8& data) {
     switch (m_state) {
     case STARTED:
-        data = m_reg_ptr;
-        m_state = MSB;
-        return I2C_ACK;
     case MSB:
         data = m_regs[m_reg_ptr] >> 8;
         m_state = LSB;


### PR DESCRIPTION
First issue: `i2c_read()` implemented non-existing start state in the transmit mode (likely a copy-paste error from the write function).
After a start transaction, the ADS1015 first returns the MSB on, and then returns the LSB on the subsequent read.
If you are interested in the details, read "7.5.2.2 Transmit Mode" in the official documentation.

```c++
i2c_response ads1015::i2c_read(const i2c_target_socket& socket, u8& data) {
    switch (m_state) {
    case STARTED:           // Doesn't exist!
        data = m_reg_ptr;   // ...
        m_state = MSB;      // ...
        return I2C_ACK;     // ...
    case MSB:
        data = m_regs[m_reg_ptr] >> 8;
        m_state = LSB;
        return I2C_ACK;
    case LSB:
        data = m_regs[m_reg_ptr];
        if (m_reg_ptr == CONVERT)
            post_read();
        m_state = MSB;
        return I2C_ACK;
    default:
        return I2C_NACK;
    }
}
```

Second issue: `update_config()` cleared the OS (operational status) bit in the CONFIG register when a conversion started but never set it back to 1.
If you are interested in the details, read "7.4.2.1 Single-Shot Mode" in the official documentation.

```c++
if (config & ADS1015_OS) {
    config &= ~ADS1015_OS;
    sample_data();
    config |= ADS1015_OS; // This is needed. Otherwise, the conversion never finishes!
```