### PR TITLE
fix: nack response on start should not advance state

### DIFF
--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -70,6 +70,8 @@ void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
         socket.trace_fw(tx);
         state = i2c_decode_tlm_command(tx.data);
         tx.resp = i2c_start(socket, state);
+        if (failed(tx.resp))
+            state = TLM_IGNORE_COMMAND;
         socket.trace_bw(tx);
         return;
     }

--- a/test/models/i2c_opencores.cpp
+++ b/test/models/i2c_opencores.cpp
@@ -56,6 +56,11 @@ public:
         clk.bind(model.clk);
         model.irq.bind(irq);
         model.i2c.bind(i2c);
+
+        add_test("setup", &sifive_i2c_bench::test_setup);
+        add_test("write", &sifive_i2c_bench::test_write);
+        add_test("read", &sifive_i2c_bench::test_read);
+        add_test("error", &sifive_i2c_bench::test_error);
     }
 
     tlm_response_status reg_read(u32 addr, DATA& val) {
@@ -85,6 +90,9 @@ public:
 
     void test_write() {
         DATA data = 0;
+
+        // enable device, interrupts masked
+        EXPECT_OK(reg_write(CTR, oci2c::CTR_EN));
 
         // setup write operation
         ASSERT_OK(reg_write(TXR, i2c_addr_w(42)));
@@ -176,21 +184,14 @@ public:
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, oci2c::SR_NACK | oci2c::SR_IF);
 
-        // finish transfer
-        EXPECT_CALL(*this, i2c_stop(_)).Times(1).WillOnce(Return(I2C_NACK));
+        // start was already rejected, so it should not see the stop condition
+        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
         ASSERT_OK(reg_write(CR, oci2c::CMD_STO | oci2c::CMD_IACK));
         ASSERT_OK(reg_read(SR, data));
         EXPECT_EQ(data, oci2c::SR_NACK | oci2c::SR_IF);
         ASSERT_OK(reg_write(CR, oci2c::CMD_IACK));
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, 0) << "unexpected status received";
-    }
-
-    virtual void run_test() override {
-        test_setup();
-        test_write();
-        test_read();
-        test_error();
     }
 };
 

--- a/test/models/i2c_sifive.cpp
+++ b/test/models/i2c_sifive.cpp
@@ -51,6 +51,11 @@ public:
         clk.bind(model.clk);
         model.irq.bind(irq);
         model.i2c.bind(i2c);
+
+        add_test("setup", &sifive_i2c_bench::test_setup);
+        add_test("write", &sifive_i2c_bench::test_write);
+        add_test("read", &sifive_i2c_bench::test_read);
+        add_test("error", &sifive_i2c_bench::test_error);
     }
 
     tlm_response_status reg_read(u32 addr, u8& val) {
@@ -80,6 +85,9 @@ public:
 
     void test_write() {
         u8 data = 0;
+
+        // enable device, interrupts masked
+        EXPECT_OK(reg_write(CTR, i2c::sifive::CTR_EN));
 
         // setup write operation
         ASSERT_OK(reg_write(TXR, i2c_addr_w(42)));
@@ -172,8 +180,8 @@ public:
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, i2c::sifive::SR_NACK | i2c::sifive::SR_IF);
 
-        // finish transfer
-        EXPECT_CALL(*this, i2c_stop(_)).Times(1).WillOnce(Return(I2C_NACK));
+        // start was already rejected, so it should not see the stop condition
+        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
         ASSERT_OK(reg_write(CR, i2c::sifive::CMD_STO | i2c::sifive::CMD_IACK));
         ASSERT_OK(reg_read(SR, data));
         EXPECT_EQ(data, i2c::sifive::SR_NACK | i2c::sifive::SR_IF);
@@ -181,16 +189,9 @@ public:
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, 0) << "unexpected status received";
     }
-
-    virtual void run_test() override {
-        test_setup();
-        test_write();
-        test_read();
-        test_error();
-    }
 };
 
-TEST(i2c_sigive, simulate) {
+TEST(i2c_sifive, simulate) {
     sifive_i2c_bench test("test");
     sc_core::sc_start();
 }

--- a/test/unit/i2c.cpp
+++ b/test/unit/i2c.cpp
@@ -135,6 +135,7 @@ public:
 
         add_test("protocol", &i2c_bench::test_protocol);
         add_test("bus", &i2c_bench::test_bus);
+        add_test("start_nack", &i2c_bench::test_start_nack);
     }
 
     MOCK_METHOD(i2c_response, i2c_start,
@@ -221,6 +222,20 @@ public:
         EXPECT_ACK(i2c_bus_master2.stop());
 
         EXPECT_NACK(i2c_bus_master1.start(99, TLM_WRITE_COMMAND));
+    }
+
+    void test_start_nack() {
+        EXPECT_CALL(*this, i2c_start(i2c_match_address(45), TLM_WRITE_COMMAND))
+            .Times(1)
+            .WillOnce(Return(I2C_NACK));
+        EXPECT_NACK(i2c_out.start(45, TLM_WRITE_COMMAND));
+
+        u8 data = 0x42;
+        EXPECT_CALL(*this, i2c_write(i2c_match_address(45), data)).Times(0);
+        EXPECT_NACK(i2c_out.transport(data));
+
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(45))).Times(0);
+        EXPECT_NACK(i2c_out.stop());
     }
 };
 


### PR DESCRIPTION
When starting an I2C transaction with `i2c_start`, models can also reject that by responding with `I2C_NACK`.
None of the models is currently doing that, but future models (like I2c EEPROMS with a notion of timing) may do so.

With our current implementation, even a negative response advances the I2C target's state to either read or write:
```c++
void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
    ...
    switch (tx.cmd) {
    case I2C_START: {
        state = TLM_IGNORE_COMMAND;

        u8 address = i2c_decode_address(tx.data);
        if (address != I2C_ADDR_BCAST && address != socket.address)
            return;

        socket.trace_fw(tx);
        state = i2c_decode_tlm_command(tx.data); // BUG: State is advanced regardless of the response.
        tx.resp = i2c_start(socket, state);
        // if (failed(tx.resp))                  // FIX: These lines are needed to rectify the state!
        //    state = TLM_IGNORE_COMMAND;
        socket.trace_bw(tx);
        return;
    }
```
This PR rectifies that.

This change broke one of the tests in `i2c_opencores.cpp`, which was expecting a call to `i2c_stop` even though `i2c_start` was rejected. I fixed that as well.

While I was at it, I also adapted the test to the new test infrastructure.
That broke the write test, because it didn't account for resetting between tests.
I guess that was an oversight because the read test does everything correctly.
The missing reset between tests was an oversight as well, I assume.

The same stuff also broke in `i2c_sifive.cpp`, which looked like a copied version of `i2c_opencores.cpp`.
Fixed the typo sigive -> sifive as well.

