### PR TITLE
fix: i2c nack on start

### DIFF
--- a/include/vcml/protocols/i2c.h
+++ b/include/vcml/protocols/i2c.h
@@ -80,7 +80,12 @@ class i2c_target_stub;
 class i2c_host
 {
 private:
-    unordered_map<u8, tlm_command> m_state;
+    struct i2c_state {
+        tlm_command cmd = TLM_IGNORE_COMMAND;
+        bool selected = false;
+    };
+
+    unordered_map<u8, i2c_state> m_state;
 
 public:
     i2c_host() = default;

--- a/include/vcml/protocols/i2c.h
+++ b/include/vcml/protocols/i2c.h
@@ -80,9 +80,11 @@ class i2c_target_stub;
 class i2c_host
 {
 private:
-    struct i2c_state {
-        tlm_command cmd = TLM_IGNORE_COMMAND;
-        bool selected = false;
+   enum i2c_state {
+       I2C_LISTEN = 0,
+       I2C_START_NACK,
+       I2C_READ,
+       I2C_WRITE,
     };
 
     unordered_map<u8, i2c_state> m_state;

--- a/include/vcml/protocols/i2c.h
+++ b/include/vcml/protocols/i2c.h
@@ -80,11 +80,11 @@ class i2c_target_stub;
 class i2c_host
 {
 private:
-   enum i2c_state {
-       I2C_LISTEN = 0,
-       I2C_START_NACK,
-       I2C_READ,
-       I2C_WRITE,
+    enum i2c_state {
+        I2C_LISTEN = 0,
+        I2C_START_NACK,
+        I2C_READ,
+        I2C_WRITE,
     };
 
     unordered_map<u8, i2c_state> m_state;

--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -52,43 +52,44 @@ ostream& operator<<(ostream& os, const i2c_payload& tx) {
 }
 
 void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
-    if (!stl_contains(m_state, socket.address.get()))
-        m_state[socket.address.get()] = TLM_IGNORE_COMMAND;
-
-    tlm_command& state = m_state[socket.address];
-    if (state == TLM_IGNORE_COMMAND && tx.cmd != I2C_START)
+    i2c_state& state = m_state[socket.address];
+    if (!state.selected && tx.cmd != I2C_START)
         return;
 
     switch (tx.cmd) {
     case I2C_START: {
-        state = TLM_IGNORE_COMMAND;
+        state = i2c_state();
 
         u8 address = i2c_decode_address(tx.data);
         if (address != I2C_ADDR_BCAST && address != socket.address)
             return;
 
         socket.trace_fw(tx);
-        state = i2c_decode_tlm_command(tx.data);
-        tx.resp = i2c_start(socket, state);
+        state.selected = true;
+        state.cmd = i2c_decode_tlm_command(tx.data);
+        tx.resp = i2c_start(socket, state.cmd);
         if (failed(tx.resp))
-            state = TLM_IGNORE_COMMAND;
+            state.cmd = TLM_IGNORE_COMMAND;
         socket.trace_bw(tx);
         return;
     }
 
     case I2C_STOP: {
         socket.trace_fw(tx);
-        state = TLM_IGNORE_COMMAND;
+        state = i2c_state();
         tx.resp = i2c_stop(socket);
         socket.trace_bw(tx);
         return;
     }
 
     case I2C_DATA: {
+        if (state.cmd == TLM_IGNORE_COMMAND)
+            return;
+
         socket.trace_fw(tx);
-        if (state == TLM_READ_COMMAND)
+        if (state.cmd == TLM_READ_COMMAND)
             tx.resp = i2c_read(socket, tx.data);
-        if (state == TLM_WRITE_COMMAND)
+        if (state.cmd == TLM_WRITE_COMMAND)
             tx.resp = i2c_write(socket, tx.data);
         socket.trace_bw(tx);
         return;

--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -65,12 +65,12 @@ void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
         socket.trace_fw(tx);
 
         if (i2c_decode_tlm_command(tx.data) == TLM_READ_COMMAND) {
-        	state = I2C_READ;
-        	tx.resp = i2c_start(socket, TLM_READ_COMMAND);
+            state = I2C_READ;
+            tx.resp = i2c_start(socket, TLM_READ_COMMAND);
         } else {
-        	state = I2C_WRITE;
-        	tx.resp = i2c_start(socket, TLM_WRITE_COMMAND);
-	    }
+            state = I2C_WRITE;
+            tx.resp = i2c_start(socket, TLM_WRITE_COMMAND);
+        }
 
         if (failed(tx.resp))
             state = I2C_START_NACK;
@@ -92,7 +92,7 @@ void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
 
     case I2C_DATA: {
         if (state != I2C_READ && state != I2C_WRITE)
-           return;
+            return;
 
         socket.trace_fw(tx);
         if (state == I2C_READ)

--- a/src/vcml/protocols/i2c.cpp
+++ b/src/vcml/protocols/i2c.cpp
@@ -53,43 +53,51 @@ ostream& operator<<(ostream& os, const i2c_payload& tx) {
 
 void i2c_host::i2c_transport(i2c_target_socket& socket, i2c_payload& tx) {
     i2c_state& state = m_state[socket.address];
-    if (!state.selected && tx.cmd != I2C_START)
-        return;
 
     switch (tx.cmd) {
     case I2C_START: {
-        state = i2c_state();
+        state = I2C_LISTEN;
 
         u8 address = i2c_decode_address(tx.data);
         if (address != I2C_ADDR_BCAST && address != socket.address)
             return;
 
         socket.trace_fw(tx);
-        state.selected = true;
-        state.cmd = i2c_decode_tlm_command(tx.data);
-        tx.resp = i2c_start(socket, state.cmd);
+
+        if (i2c_decode_tlm_command(tx.data) == TLM_READ_COMMAND) {
+        	state = I2C_READ;
+        	tx.resp = i2c_start(socket, TLM_READ_COMMAND);
+        } else {
+        	state = I2C_WRITE;
+        	tx.resp = i2c_start(socket, TLM_WRITE_COMMAND);
+	    }
+
         if (failed(tx.resp))
-            state.cmd = TLM_IGNORE_COMMAND;
+            state = I2C_START_NACK;
+
         socket.trace_bw(tx);
         return;
     }
 
     case I2C_STOP: {
+        if (state == I2C_LISTEN)
+            return;
+
         socket.trace_fw(tx);
-        state = i2c_state();
+        state = I2C_LISTEN;
         tx.resp = i2c_stop(socket);
         socket.trace_bw(tx);
         return;
     }
 
     case I2C_DATA: {
-        if (state.cmd == TLM_IGNORE_COMMAND)
-            return;
+        if (state != I2C_READ && state != I2C_WRITE)
+           return;
 
         socket.trace_fw(tx);
-        if (state.cmd == TLM_READ_COMMAND)
+        if (state == I2C_READ)
             tx.resp = i2c_read(socket, tx.data);
-        if (state.cmd == TLM_WRITE_COMMAND)
+        if (state == I2C_WRITE)
             tx.resp = i2c_write(socket, tx.data);
         socket.trace_bw(tx);
         return;

--- a/test/models/i2c_opencores.cpp
+++ b/test/models/i2c_opencores.cpp
@@ -18,7 +18,9 @@ template <typename DATA, const u8 REG_SHIFT>
 class sifive_i2c_bench : public test_base, public i2c_host
 {
 public:
-    constexpr DATA i2c_addr_w(u8 addr) { return (DATA)addr << 1; }
+    test / models / i2c_sifive.cpp constexpr DATA i2c_addr_w(u8 addr) {
+        return (DATA)addr << 1;
+    }
     constexpr DATA i2c_addr_r(u8 addr) { return (DATA)addr << 1 | 1; }
 
     enum address : u32 {
@@ -184,8 +186,8 @@ public:
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, oci2c::SR_NACK | oci2c::SR_IF);
 
-        // start was already rejected, so it should not see the stop condition
-        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
+        // finish transfer
+        EXPECT_CALL(*this, i2c_stop(_)).Times(1).WillOnce(Return(I2C_NACK));
         ASSERT_OK(reg_write(CR, oci2c::CMD_STO | oci2c::CMD_IACK));
         ASSERT_OK(reg_read(SR, data));
         EXPECT_EQ(data, oci2c::SR_NACK | oci2c::SR_IF);

--- a/test/models/i2c_opencores.cpp
+++ b/test/models/i2c_opencores.cpp
@@ -18,9 +18,7 @@ template <typename DATA, const u8 REG_SHIFT>
 class sifive_i2c_bench : public test_base, public i2c_host
 {
 public:
-    test / models / i2c_sifive.cpp constexpr DATA i2c_addr_w(u8 addr) {
-        return (DATA)addr << 1;
-    }
+    constexpr DATA i2c_addr_w(u8 addr) { return (DATA)addr << 1; }
     constexpr DATA i2c_addr_r(u8 addr) { return (DATA)addr << 1 | 1; }
 
     enum address : u32 {

--- a/test/models/i2c_sifive.cpp
+++ b/test/models/i2c_sifive.cpp
@@ -180,8 +180,8 @@ public:
         ASSERT_OK(reg_read(SR, data));
         ASSERT_EQ(data, i2c::sifive::SR_NACK | i2c::sifive::SR_IF);
 
-        // start was already rejected, so it should not see the stop condition
-        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
+        // finish transfer
+        EXPECT_CALL(*this, i2c_stop(_)).Times(1).WillOnce(Return(I2C_NACK));
         ASSERT_OK(reg_write(CR, i2c::sifive::CMD_STO | i2c::sifive::CMD_IACK));
         ASSERT_OK(reg_read(SR, data));
         EXPECT_EQ(data, i2c::sifive::SR_NACK | i2c::sifive::SR_IF);

--- a/test/unit/i2c.cpp
+++ b/test/unit/i2c.cpp
@@ -136,6 +136,7 @@ public:
         add_test("protocol", &i2c_bench::test_protocol);
         add_test("bus", &i2c_bench::test_bus);
         add_test("start_nack", &i2c_bench::test_start_nack);
+        add_test("repeated_start", &i2c_bench::test_repeated_start);
     }
 
     MOCK_METHOD(i2c_response, i2c_start,
@@ -234,8 +235,44 @@ public:
         EXPECT_CALL(*this, i2c_write(i2c_match_address(45), data)).Times(0);
         EXPECT_NACK(i2c_out.transport(data));
 
-        EXPECT_CALL(*this, i2c_stop(i2c_match_address(45))).Times(0);
+        // target rejected address, but it must still see a subsequent stop
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(45)))
+            .Times(1)
+            .WillOnce(Return(I2C_NACK));
         EXPECT_NACK(i2c_out.stop());
+
+        // another stop will remain unnoticed
+        EXPECT_CALL(*this, i2c_stop(_)).Times(0);
+        EXPECT_NACK(i2c_out.stop());
+    }
+
+    void test_repeated_start() {
+        EXPECT_CALL(*this, i2c_start(i2c_match_address(44), TLM_WRITE_COMMAND))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_out.start(44, TLM_WRITE_COMMAND));
+
+        // repeated start for another target, no stop condition in between
+        EXPECT_CALL(*this, i2c_start(i2c_match_address(45), TLM_READ_COMMAND))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_out.start(45, TLM_READ_COMMAND));
+
+        // data must only go to the newly selected target
+        u8 data = 0;
+        EXPECT_CALL(*this, i2c_write(_, _)).Times(0);
+        EXPECT_CALL(*this, i2c_read(i2c_match_address(45), _))
+            .Times(1)
+            .WillOnce(DoAll(SetArgReferee<1>(0x37), Return(I2C_ACK)));
+        EXPECT_ACK(i2c_out.transport(data));
+        EXPECT_EQ(data, 0x37);
+
+        // the deselected target must not see the stop condition
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(44))).Times(0);
+        EXPECT_CALL(*this, i2c_stop(i2c_match_address(45)))
+            .Times(1)
+            .WillOnce(Return(I2C_ACK));
+        EXPECT_ACK(i2c_out.stop());
     }
 };
 


### PR DESCRIPTION
Here we go with another take on I2C.

This PR introduces a selected state, that is used to indicate if a target is currently addressed by an initiator.
Until now, there was a corner case in which a target would respond with NACK to START, leading to the STOP not being delivered because its state was put into TLM_IGNORE_COMMAND.
With the extra I2C_START_NACK state, a  NACKed START can now be associated to a STOP.
Note that repeated START commands reset the state, for which I added an additional test.

With that change, I can also reroll the tests of i2c_opencores and i2c_sifive to their old implementation.

